### PR TITLE
Ontology model extensions

### DIFF
--- a/common/ontology/apartment.owl
+++ b/common/ontology/apartment.owl
@@ -20,7 +20,7 @@
     <owl:Class rdf:about="apartment:Plane"/>
     <owl:Class rdf:about="apartment:Room"/>
     <owl:Class rdf:about="apartment:Location"/>
-    <owl:Class rdf:about="apartment:Coordinate"/>
+    <owl:Class rdf:about="apartment:NamedPose"/>
 
     <!-- Furniture items -->
     <owl:Class rdf:about="apartment:Furniture"/>
@@ -148,12 +148,18 @@
         <owl:inverseOf rdf:resource="#apartment:toTheLeftOf"/>
     </owl:ObjectProperty>
 
-    <owl:DatatypeProperty rdf:about="apartment:position">
+    <owl:ObjectProperty rdf:about="apartment:isAtNamedPose">
         <rdfs:domain rdf:resource="apartment:Thing"/>
-        <rdfs:range rdf:resource="xsd:float"/>
-    </owl:DatatypeProperty>
+        <rdfs:range rdf:resource="apartment:NamedPose"/>
+    </owl:ObjectProperty>
 
-    <owl:DatatypeProperty rdf:about="apartment:orientation">
+    <owl:ObjectProperty rdf:about="apartment:isAtLocation">
+        <rdfs:domain rdf:resource="apartment:NamedPose"/>
+        <rdfs:range rdf:resource="apartment:Location"/>
+    </owl:ObjectProperty>
+
+
+    <owl:DatatypeProperty rdf:about="apartment:pose">
         <rdfs:domain rdf:resource="apartment:Thing"/>
         <rdfs:range rdf:resource="xsd:float"/>
     </owl:DatatypeProperty>
@@ -172,6 +178,10 @@
     </owl:Class>
 
     <owl:Class rdf:about="apartment:Plane">
+        <rdfs:subClassOf rdf:resource="apartment:Thing"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="apartment:NamedPose">
         <rdfs:subClassOf rdf:resource="apartment:Thing"/>
     </owl:Class>
 
@@ -369,6 +379,14 @@
 
 
     <!--*********** Subproperty definitions ************-->
+    <owl:DatatypeProperty rdf:about="apartment:position">
+        <rdfs:subPropertyOf rdf:resource="apartment:pose"/>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="apartment:orientation">
+        <rdfs:subPropertyOf rdf:resource="apartment:pose"/>
+    </owl:DatatypeProperty>
+
     <owl:DatatypeProperty rdf:about="apartment:positionX">
         <rdfs:subPropertyOf rdf:resource="apartment:position"/>
     </owl:DatatypeProperty>

--- a/common/ontology/apartment.owl
+++ b/common/ontology/apartment.owl
@@ -18,6 +18,7 @@
     <owl:Class rdf:about="apartment:Plane"/>
     <owl:Class rdf:about="apartment:Room"/>
     <owl:Class rdf:about="apartment:Location"/>
+    <owl:Class rdf:about="apartment:Coordinate"/>
 
     <!-- Furniture items -->
     <owl:Class rdf:about="apartment:Furniture"/>
@@ -144,6 +145,16 @@
     <owl:ObjectProperty rdf:about="apartment:toTheRightOf">
         <owl:inverseOf rdf:resource="#apartment:toTheLeftOf"/>
     </owl:ObjectProperty>
+
+    <owl:DatatypeProperty rdf:about="apartment:position">
+        <rdfs:domain rdf:resource="apartment:Coordinate"/>
+        <rdfs:range rdf:resource="xsd:float"/>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="apartment:orientation">
+        <rdfs:domain rdf:resource="apartment:Coordinate"/>
+        <rdfs:range rdf:resource="xsd:float"/>
+    </owl:DatatypeProperty>
     <!--*********************************************-->
 
 
@@ -339,6 +350,33 @@
     <owl:Class rdf:about="apartment:ToiletPaper">
       <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
     </owl:Class>
+    <!--*********************************************-->
+
+
+    <!--*********** Subproperty definitions ************-->
+    <owl:DatatypeProperty rdf:about="apartment:positionX">
+        <rdfs:subPropertyOf rdf:resource="apartment:position"/>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="apartment:positionY">
+        <rdfs:subPropertyOf rdf:resource="apartment:position"/>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="apartment:positionZ">
+        <rdfs:subPropertyOf rdf:resource="apartment:position"/>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="apartment:orientationRoll">
+        <rdfs:subPropertyOf rdf:resource="apartment:orientation"/>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="apartment:orientationPitch">
+        <rdfs:subPropertyOf rdf:resource="apartment:orientation"/>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="apartment:orientationYaw">
+        <rdfs:subPropertyOf rdf:resource="apartment:orientation"/>
+    </owl:DatatypeProperty>
     <!--*********************************************-->
 
 

--- a/common/ontology/apartment.owl
+++ b/common/ontology/apartment.owl
@@ -21,6 +21,7 @@
     <owl:Class rdf:about="apartment:Room"/>
     <owl:Class rdf:about="apartment:Location"/>
     <owl:Class rdf:about="apartment:NamedPose"/>
+    <owl:Class rdf:about="apartment:GraspingStrategy"/>
 
     <!-- Furniture items -->
     <owl:Class rdf:about="apartment:Furniture"/>
@@ -158,6 +159,10 @@
         <rdfs:range rdf:resource="apartment:Location"/>
     </owl:ObjectProperty>
 
+    <owl:ObjectProperty rdf:about="apartment:preferredGraspingStrategy">
+        <rdfs:domain rdf:resource="apartment:Object"/>
+        <rdfs:range rdf:resource="apartment:GraspingStrategy"/>
+    </owl:ObjectProperty>
 
     <owl:DatatypeProperty rdf:about="apartment:pose">
         <rdfs:domain rdf:resource="apartment:Thing"/>
@@ -182,6 +187,10 @@
     </owl:Class>
 
     <owl:Class rdf:about="apartment:NamedPose">
+        <rdfs:subClassOf rdf:resource="apartment:Thing"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="apartment:GraspingStrategy">
         <rdfs:subClassOf rdf:resource="apartment:Thing"/>
     </owl:Class>
 
@@ -508,5 +517,13 @@
             <owl:Class rdf:about="apartment:ToiletPaper"/>
         </owl:members>
     </owl:AllDisjointClasses>
+    <!--*********************************************-->
+
+
+    <!--****** Class assertions *******-->
+
+    <apartment:GraspingStrategy rdf:about="Sideways"/>
+    <apartment:GraspingStrategy rdf:about="TopDown"/>
+
     <!--*********************************************-->
 </rdf:RDF>

--- a/common/ontology/apartment.owl
+++ b/common/ontology/apartment.owl
@@ -14,6 +14,8 @@
     <owl:Ontology rdf:about="http://apartment" />
 
     <!--************* Class definitions ************-->
+    <owl:Class rdf:about="apartment:Thing"/>
+
     <owl:Class rdf:about="apartment:Object"/>
     <owl:Class rdf:about="apartment:Plane"/>
     <owl:Class rdf:about="apartment:Room"/>
@@ -147,18 +149,31 @@
     </owl:ObjectProperty>
 
     <owl:DatatypeProperty rdf:about="apartment:position">
-        <rdfs:domain rdf:resource="apartment:Coordinate"/>
+        <rdfs:domain rdf:resource="apartment:Thing"/>
         <rdfs:range rdf:resource="xsd:float"/>
     </owl:DatatypeProperty>
 
     <owl:DatatypeProperty rdf:about="apartment:orientation">
-        <rdfs:domain rdf:resource="apartment:Coordinate"/>
+        <rdfs:domain rdf:resource="apartment:Thing"/>
         <rdfs:range rdf:resource="xsd:float"/>
     </owl:DatatypeProperty>
     <!--*********************************************-->
 
 
     <!--*********** Subclass definitions ************-->
+
+    <!-- Thing subclass definitions -->
+    <owl:Class rdf:about="apartment:Object">
+        <rdfs:subClassOf rdf:resource="apartment:Thing"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="apartment:Location">
+        <rdfs:subClassOf rdf:resource="apartment:Thing"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="apartment:Plane">
+        <rdfs:subClassOf rdf:resource="apartment:Thing"/>
+    </owl:Class>
 
     <!-- Location subclass definitions -->
     <owl:Class rdf:about="apartment:Room">

--- a/common/ontology/apartment.owl
+++ b/common/ontology/apartment.owl
@@ -273,6 +273,9 @@
     <owl:Class rdf:about="apartment:Cupboard">
       <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
+    <owl:Class rdf:about="apartment:Sink">
+      <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
+    </owl:Class>
 
     <!-- Kitchen item subclass definitions -->
     <owl:Class rdf:about="apartment:Fork">
@@ -330,11 +333,11 @@
     <owl:Class rdf:about="apartment:DrinkingGlass">
       <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
     </owl:Class>
-    <owl:Class rdf:about="apartment:DrinkingGlass">
-      <rdfs:subClassOf rdf:resource="apartment:ShotGlass"/>
+    <owl:Class rdf:about="apartment:ShotGlass">
+      <rdfs:subClassOf rdf:resource="apartment:DrinkingGlass"/>
     </owl:Class>
-    <owl:Class rdf:about="apartment:DrinkingGlass">
-      <rdfs:subClassOf rdf:resource="apartment:WineGlass"/>
+    <owl:Class rdf:about="apartment:WineGlass">
+      <rdfs:subClassOf rdf:resource="apartment:DrinkingGlass"/>
     </owl:Class>
 
     <!-- Food container subclass definitions -->


### PR DESCRIPTION
This PR extends the `apartment` ontology:

* [x] A base concept `Thing` has been added (as always done in ontologies)
* [x] 3D object poses can be defined
* [x] 3D poses can also be mapped to semantic locations
* [x] preferred grasp strategies for different objects can be defined

Various errors in the ontology have also been fixed (particularly relating to the subclass axioms).