### PR TITLE
Load and insert class and property assertions from a YAML file

### DIFF
--- a/common/assertions/test_apartment.yaml
+++ b/common/assertions/test_apartment.yaml
@@ -1,0 +1,23 @@
+class_assertions:
+    Male: [Alex, Sushant]
+    Female: [Argentina]
+    Room: [RopodLab, atWorkLab]
+    Chair: [AlexChair, ArgentinaChair, SushantChair]
+    HighTable: [RopodWorkDesk, atWorkDesk]
+property_assertions:
+    defaultLocation:
+        AlexChair: RopodLab
+        ArgentinaChair: RopodLab
+        SushantChair: RopodLab
+        RopodWorkDesk: RopodLab
+        atWorkDesk: atWorkLab
+    locatedAt:
+        AlexChair: RopodLab
+        ArgentinaChair: RopodLab
+        SushantChair: atWorkLab
+        RopodWorkDesk: RopodLab
+        atWorkDesk: atWorkLab
+    nextTo:
+        AlexChair: RopodWorkDesk
+        ArgentinaChair: RopodWorkDesk
+        SushantChair: atWorkDesk

--- a/common/mas_knowledge_utils/ABox.py
+++ b/common/mas_knowledge_utils/ABox.py
@@ -1,0 +1,134 @@
+import yaml
+import argparse
+import os
+from ontology_query_interface import OntologyQueryInterface
+
+# TODO: name of this class?
+class PopulateABox:
+    '''Updates an ontology with class and property assertions 
+    that are specified in a yaml file.
+
+    Constructor arguments:
+    @param ontology_file -- full URL of an ontology file (of the form file://<absolute-path>)
+    @param ontology_class_prefix -- class prefix of the items in the given ontology
+    @param assertions_file -- absolute-path to the yaml file containing assertions
+
+    @author Sushant Chavan
+    @contact sushant.chavan@smail.inf.h-brs.de
+
+    '''
+    def __init__(self, ontology_file, ontology_class_prefix, assertions_file):
+        self.ontology_if = OntologyQueryInterface(ontology_file=ontology_file,
+                                    class_prefix=ontology_class_prefix)
+        self.class_assertions = None
+        self.property_assertions = None
+
+        self.__load_assertions(assertions_file)
+
+    def update_ontology(self, export_path):
+        '''Inserts the class and property assertions and updates/exports the ontology.
+
+        Keyword arguments:
+        export_path -- string representing the filepath (of the form file://<absolute-path>)
+                       if the ontology has to be exported to a new file. 
+                       If it is 'None', the loaded ontology will be updated with the assertions
+
+        '''
+        self.process_class_assertions()
+        self.process_property_assertions()
+        self.export_ontology(export_path)
+
+    def process_class_assertions(self):
+        '''Inserts the class assertions into the loaded ontology.
+
+        '''
+        if self.class_assertions is None:
+            return
+
+        for class_name in self.class_assertions.keys():
+            instance_names = self.class_assertions[class_name]
+            for instance_name in instance_names:
+                self.ontology_if.insert_class_assertion(class_name, instance_name)
+                #print("Inserting class assertion: {0}, {1}".format(class_name, instance_name))
+
+    def process_property_assertions(self):
+        '''Inserts the property assertions into the loaded ontology.
+
+        '''
+        if self.property_assertions is None:
+            return
+
+        for property_name in self.property_assertions.keys():
+            for subj, obj in self.property_assertions[property_name].items():
+                self.ontology_if.insert_property_assertion(property_name, (subj, obj))
+                #print("Inserting property assertion: {0}, {1}, {2}".format(subj, property_name, obj))
+
+    def export_ontology(self, export_path):
+        '''Updates/exports the ontology.
+
+        Keyword arguments:
+        export_path -- string representing the filepath (of the form file://<absolute-path>)
+                       if the ontology has to be exported to a new file. 
+                       If it is 'None', the loaded ontology will be updated with the assertions
+
+        '''
+        if export_path is None:
+            # Overwrite the existing ontology file with the updated ontology
+            print("No export filepath specified. Updating the loaded ontology.")
+            self.ontology_if.update()
+        else:
+            # Save the updated ontology at the given file location
+            print("Exporting the ontology to", export_path)
+            self.ontology_if.export(export_path)
+
+    def __load_assertions(self, assertions_file):
+        '''Loads the class and property assertions as two separate
+        dictionaries from the yaml file
+
+        Keyword arguments:
+        assertions_file -- absolute-path to the yaml file containing assertions
+
+        '''
+        assertions = None
+        with open(assertions_file, 'r') as f:
+            assertions = yaml.load(f, Loader=yaml.FullLoader)
+
+        if assertions is None:
+            raise Exception("Could not load the assertion file!")
+        else:
+            self.class_assertions = assertions['class_assertions']
+            self.property_assertions = assertions['property_assertions']
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('asserts', type=str, 
+                        help="Name of the yaml file containing the assertions \
+                              (eg.: apartment_asserts)")
+    parser.add_argument('-o', '--ontology', type=str, action='store', 
+                        help="Filename of the ontology (default: apartment_go_2019)",
+                        default='apartment_go_2019')
+    parser.add_argument('-c', '--class-prefix', type=str, action='store', 
+                        help="class prefix (or namespace) of the items in the \
+                              given ontology (default: apartment)",
+                        default='apartment')
+    parser.add_argument('-e', '--export-file', type=str, action='store', 
+                        help="Filename for exporting the updated ontology \
+                              (eg.: apartment_go_2019_updated). If not \
+                               specified, the loaded ontology will be updated.",
+                        default=None)
+
+    args = parser.parse_args()
+
+    script_dir = os.path.abspath(os.path.dirname(__file__))
+    ontology_dir = os.path.join(os.path.dirname(script_dir), "ontology")
+    assertions_dir = os.path.join(os.path.dirname(script_dir), "assertions")
+
+    ontology_file_path = "file://" + os.path.join(ontology_dir, args.ontology + ".owl")
+    assertions_file_path = os.path.join(assertions_dir, args.asserts + ".yaml")
+
+    export_file_path = None
+    if args.export_file is not None:
+        export_file_path = "file://" + os.path.join(ontology_dir, args.export_file + ".owl")
+
+    aBox = PopulateABox(ontology_file_path, args.class_prefix, assertions_file_path)
+    aBox.update_ontology(export_file_path)

--- a/common/mas_knowledge_utils/abox_yaml_loader.py
+++ b/common/mas_knowledge_utils/abox_yaml_loader.py
@@ -3,8 +3,7 @@ import argparse
 import os
 from ontology_query_interface import OntologyQueryInterface
 
-# TODO: name of this class?
-class PopulateABox:
+class ABoxYAMLLoader:
     '''Updates an ontology with class and property assertions 
     that are specified in a yaml file.
 
@@ -130,5 +129,5 @@ if __name__ == '__main__':
     if args.export_file is not None:
         export_file_path = "file://" + os.path.join(ontology_dir, args.export_file + ".owl")
 
-    aBox = PopulateABox(ontology_file_path, args.class_prefix, assertions_file_path)
-    aBox.update_ontology(export_file_path)
+    loader = ABoxYAMLLoader(ontology_file_path, args.class_prefix, assertions_file_path)
+    loader.update_ontology(export_file_path)

--- a/common/mas_knowledge_utils/ontology_query_interface.py
+++ b/common/mas_knowledge_utils/ontology_query_interface.py
@@ -298,6 +298,7 @@ class OntologyQueryInterface(object):
                                       rdflib.URIRef(ns[property_name]),
                                       rdflib.URIRef(self.__get_entity_url(instance[1]))))
 
+    # TODO: default export file format?
     def export(self, ontology_file, format='xml'):
         '''Exports the ontology as an xml document.
 

--- a/common/ontology/apartment_go_2019.owl
+++ b/common/ontology/apartment_go_2019.owl
@@ -99,10 +99,6 @@
         <rdfs:subClassOf rdf:resource="apartment:Room"/>
     </owl:Class>
 
-    <owl:Class rdf:about="apartment:Furniture">
-        <rdfs:subClassOf rdf:resource="apartment:Object"/>
-    </owl:Class>
-
     <!-- Furniture Subclass -->
     <owl:Class rdf:about="apartment:Bed">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>

--- a/common/ontology/apartment_go_2019.owl
+++ b/common/ontology/apartment_go_2019.owl
@@ -156,7 +156,7 @@
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
 
-    <owl:Class rdf:about="apartment:Cupboard">
+    <owl:Class rdf:about="apartment:CupBoard">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
 
@@ -184,7 +184,7 @@
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
 
-    <owl:Class rdf:about="apartment:Coathanger">
+    <owl:Class rdf:about="apartment:CoatHanger">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
 


### PR DESCRIPTION
The PR adds support to load custom assertions about instances of classes or properties between classes from a YAML file and insert them into an ontology using the ontology interface.

## Changelog
<!-- Add a list of bullets with the summary of your changes -->
<!-- Try to use infinitives: Fix, Remove, Rename, Add, Refactor -->

* Updated the onotology_interface to support inserting class and property assertions.
* Validation is performed while inserting assertions to check if the classes, instances or properties exist in the ontology.
* Implemented a new script to load custom class and property assertions from a YAML file and use the ontology_interface to insert these assertions into an ontology.
* Added a sample assertions YAML file containing a few class and property assertions.
* Removed duplicated Furniture class declaration from the `apartment_go_2019.owl ` ontology.
* Fixed capitalization of class names in the `apartment_go_2019.owl ` ontology.

Closes #2 
Related to #YY

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
