### PR TITLE
Ontology interface usage examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
+.ipynb_checkpoints/
 docs/html/*
 docs/latex/*

--- a/examples/ontology_interface.ipynb
+++ b/examples/ontology_interface.ipynb
@@ -2,14 +2,22 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "# Ontology Query Interface Usage Examples"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "source": [
     "The query interface is part of the `mas_knowledge_utils` package and we can import it as follows:"
    ]
@@ -17,7 +25,11 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [],
    "source": [
     "from mas_knowledge_utils.ontology_query_interface import OntologyQueryInterface"
@@ -25,14 +37,22 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "### Initialising an Instance of the Ontology Interface"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "source": [
     "Instances of the query interface expect two arguments to be passed:\n",
     "* `ontology_url`: URL at which the ontology is exposed (if the ontology is read from a local file, the path should be prefixed by `file://`)\n",
@@ -44,7 +64,11 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [],
    "source": [
     "ontology_url = 'https://raw.githubusercontent.com/b-it-bots/mas_knowledge_base/master/common/ontology/apartment_go_2019.owl'\n",
@@ -54,14 +78,22 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "### Reading Out Class Data"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "source": [
     "The interface allows retrieving various class-related aspects from the TBox. For instance, we can obtain all classes in the ontology using the `get_classes` function:"
    ]
@@ -70,14 +102,17 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "scrolled": true
+    "scrolled": true,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['Sofa', 'Toothpaste', 'CoffeeTable', 'KitchenCabinet', 'KitchenStuff', 'Fork', 'Pepper', 'BigCoke', 'Coathanger', 'FruitBarForestFruit', 'Snacks', 'PeanutBits', 'SeasoningMix', 'WhiteDrawer', 'Female', 'Other', 'Kitchen', 'Desk', 'Corn', 'Couch', 'RedSpritzer', 'Knife', 'Cracker', 'LivingRoom', 'Sideboard', 'FruitBarApple', 'Male', 'Furniture', 'Spoon', 'Container', 'Cabinet', 'CleaningStuff', 'CerealBarChocolateBanana', 'Person', 'Bedroom', 'Bed', 'SparklingWater', 'Room', 'TV', 'TrashBin', 'Trashbag', 'SideTable', 'BarTable', 'Chair', 'Cup', 'Object', 'Fruit', 'Bowl', 'KitchenTable', 'DishwasherTab', 'GetIt', 'IsoDrink', 'Care', 'ShowerGel', 'Cloth', 'Location', 'Salt', 'TVTable', 'Dishwasher', 'BigLemonJuice', 'Bouillon', 'HighTable', 'Basket', 'CerealBarChocolate', 'Milk', 'BigWater', 'AppleJuice', 'Hallway', 'Lemon', 'Drinks', 'Tomatoes', 'Cereal', 'NutFruitMix', 'Plane', 'Orange', 'OrangeJuice', 'Sauerkraut', 'TrashCan', 'Food', 'Tray', 'Noodles', 'Cupboard', 'Plate', 'Soap', 'Wall', 'Bookcase', 'Bar']\n"
+      "['WhiteDrawer', 'Cracker', 'Female', 'Fruit', 'Spoon', 'NutFruitMix', 'OrangeJuice', 'HighTable', 'GetIt', 'Object', 'Cupboard', 'Location', 'Food', 'Noodles', 'TVTable', 'CoffeeTable', 'Couch', 'PeanutBits', 'Bar', 'Hallway', 'TrashBin', 'Lemon', 'Sofa', 'Salt', 'TrashCan', 'Wall', 'Bowl', 'CerealBarChocolate', 'Tomatoes', 'AppleJuice', 'Milk', 'SideTable', 'BarTable', 'Bouillon', 'Room', 'Dishwasher', 'FruitBarApple', 'CerealBarChocolateBanana', 'Bookcase', 'Cabinet', 'KitchenCabinet', 'Sauerkraut', 'Bedroom', 'Sideboard', 'Plate', 'Toothpaste', 'Person', 'Coathanger', 'KitchenTable', 'Kitchen', 'Cereal', 'FruitBarForestFruit', 'Knife', 'Other', 'Trashbag', 'Cloth', 'BigCoke', 'KitchenStuff', 'Soap', 'Corn', 'LivingRoom', 'Male', 'BigLemonJuice', 'Fork', 'Snacks', 'DishwasherTab', 'Desk', 'Chair', 'TV', 'RedSpritzer', 'Drinks', 'Bed', 'BigWater', 'IsoDrink', 'Basket', 'Container', 'SparklingWater', 'ShowerGel', 'Plane', 'Pepper', 'Orange', 'Cup', 'Care', 'CleaningStuff', 'Furniture', 'SeasoningMix', 'Tray']\n"
      ]
     }
    ],
@@ -88,14 +123,22 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "source": [
     "This ontology is rather small, so the number of classes is rather manageable."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "In addition to retrieving all classes, we can also retrieve a list of all parent classes of a given class:"
    ]
@@ -103,7 +146,11 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -122,7 +169,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "source": [
     "It should be noted that a class is a parent of itself, so the query class is also included in the result.\n",
     "\n",
@@ -133,13 +184,16 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "scrolled": true
+    "scrolled": true,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['KitchenStuff', 'Plate', 'Fork', 'Spoon', 'Cup', 'Knife', 'Bowl']"
+       "['KitchenStuff', 'Plate', 'Cup', 'Bowl', 'Spoon', 'Fork', 'Knife']"
       ]
      },
      "execution_count": 5,
@@ -153,17 +207,34 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "source": [
-    "As above, a class is a subclass of itself.\n",
-    "\n",
+    "As above, a class is a subclass of itself."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
     "The above functions implicitly allow us to extract the hierarchy of classes in the ontology. The interface also allows us to get the hierarchy explicitly in the form of a dictionary in which each key is a class name and the corresponding value is a list of subclasses of the class. This is done through the `get_class_hierarchy` function."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -181,7 +252,7 @@
        " 'Bouillon': [],\n",
        " 'Bowl': [],\n",
        " 'Cabinet': [],\n",
-       " 'Care': ['Toothpaste', 'ShowerGel', 'Soap'],\n",
+       " 'Care': ['Toothpaste', 'Soap', 'ShowerGel'],\n",
        " 'Cereal': [],\n",
        " 'CerealBarChocolate': [],\n",
        " 'CerealBarChocolateBanana': [],\n",
@@ -199,147 +270,147 @@
        " 'Desk': [],\n",
        " 'Dishwasher': [],\n",
        " 'DishwasherTab': [],\n",
-       " 'Drinks': ['BigLemonJuice',\n",
-       "  'IsoDrink',\n",
-       "  'RedSpritzer',\n",
-       "  'AppleJuice',\n",
-       "  'OrangeJuice',\n",
-       "  'BigCoke',\n",
+       " 'Drinks': ['AppleJuice',\n",
        "  'SparklingWater',\n",
+       "  'IsoDrink',\n",
        "  'BigWater',\n",
-       "  'Milk'],\n",
+       "  'Milk',\n",
+       "  'BigCoke',\n",
+       "  'BigLemonJuice',\n",
+       "  'OrangeJuice',\n",
+       "  'RedSpritzer'],\n",
        " 'Female': [],\n",
        " 'Food': ['Cereal',\n",
+       "  'Bouillon',\n",
+       "  'Noodles',\n",
+       "  'SeasoningMix',\n",
+       "  'Tomatoes',\n",
+       "  'Corn',\n",
        "  'Salt',\n",
        "  'Pepper',\n",
-       "  'Tomatoes',\n",
-       "  'Sauerkraut',\n",
-       "  'Noodles',\n",
-       "  'Corn',\n",
-       "  'Bouillon',\n",
-       "  'SeasoningMix'],\n",
+       "  'Sauerkraut'],\n",
        " 'Fork': [],\n",
        " 'Fruit': ['Lemon', 'Orange'],\n",
        " 'FruitBarApple': [],\n",
        " 'FruitBarForestFruit': [],\n",
-       " 'Furniture': ['Couch',\n",
-       "  'BarTable',\n",
-       "  'Cabinet',\n",
-       "  'HighTable',\n",
-       "  'KitchenTable',\n",
-       "  'Chair',\n",
+       " 'Furniture': ['Dishwasher',\n",
        "  'Coathanger',\n",
-       "  'Sofa',\n",
-       "  'TV',\n",
-       "  'Cupboard',\n",
-       "  'KitchenCabinet',\n",
-       "  'SideTable',\n",
-       "  'TVTable',\n",
-       "  'Dishwasher',\n",
-       "  'Bed',\n",
-       "  'Desk',\n",
        "  'TrashCan',\n",
-       "  'Sideboard',\n",
+       "  'SideTable',\n",
+       "  'Bed',\n",
+       "  'Bookcase',\n",
+       "  'Sofa',\n",
        "  'WhiteDrawer',\n",
-       "  'TrashBin',\n",
+       "  'Desk',\n",
+       "  'TV',\n",
+       "  'Cabinet',\n",
+       "  'KitchenTable',\n",
+       "  'BarTable',\n",
+       "  'HighTable',\n",
+       "  'Sideboard',\n",
+       "  'Cupboard',\n",
+       "  'Couch',\n",
+       "  'Chair',\n",
        "  'CoffeeTable',\n",
-       "  'Bookcase'],\n",
+       "  'TrashBin',\n",
+       "  'KitchenCabinet',\n",
+       "  'TVTable'],\n",
        " 'GetIt': [],\n",
        " 'Hallway': [],\n",
        " 'HighTable': [],\n",
        " 'IsoDrink': [],\n",
        " 'Kitchen': [],\n",
        " 'KitchenCabinet': [],\n",
-       " 'KitchenStuff': ['Plate', 'Fork', 'Spoon', 'Cup', 'Knife', 'Bowl'],\n",
+       " 'KitchenStuff': ['Plate', 'Cup', 'Bowl', 'Spoon', 'Fork', 'Knife'],\n",
        " 'KitchenTable': [],\n",
        " 'Knife': [],\n",
        " 'Lemon': [],\n",
        " 'LivingRoom': [],\n",
-       " 'Location': ['Room',\n",
-       "  'Kitchen',\n",
+       " 'Location': ['Wall',\n",
+       "  'Room',\n",
        "  'Hallway',\n",
-       "  'LivingRoom',\n",
        "  'Bar',\n",
-       "  'Bedroom',\n",
-       "  'Wall'],\n",
+       "  'Kitchen',\n",
+       "  'LivingRoom',\n",
+       "  'Bedroom'],\n",
        " 'Male': [],\n",
        " 'Milk': [],\n",
        " 'Noodles': [],\n",
        " 'NutFruitMix': [],\n",
-       " 'Object': ['CleaningStuff',\n",
-       "  'DishwasherTab',\n",
-       "  'Cloth',\n",
+       " 'Object': ['Care',\n",
+       "  'Toothpaste',\n",
+       "  'Soap',\n",
+       "  'ShowerGel',\n",
        "  'KitchenStuff',\n",
        "  'Plate',\n",
-       "  'Fork',\n",
-       "  'Spoon',\n",
        "  'Cup',\n",
-       "  'Knife',\n",
        "  'Bowl',\n",
-       "  'Container',\n",
-       "  'Tray',\n",
-       "  'Basket',\n",
+       "  'Spoon',\n",
+       "  'Fork',\n",
+       "  'Knife',\n",
        "  'Food',\n",
        "  'Cereal',\n",
+       "  'Bouillon',\n",
+       "  'Noodles',\n",
+       "  'SeasoningMix',\n",
+       "  'Tomatoes',\n",
+       "  'Corn',\n",
        "  'Salt',\n",
        "  'Pepper',\n",
-       "  'Tomatoes',\n",
        "  'Sauerkraut',\n",
-       "  'Noodles',\n",
-       "  'Corn',\n",
-       "  'Bouillon',\n",
-       "  'SeasoningMix',\n",
-       "  'Care',\n",
-       "  'Toothpaste',\n",
-       "  'ShowerGel',\n",
-       "  'Soap',\n",
+       "  'Drinks',\n",
+       "  'AppleJuice',\n",
+       "  'SparklingWater',\n",
+       "  'IsoDrink',\n",
+       "  'BigWater',\n",
+       "  'Milk',\n",
+       "  'BigCoke',\n",
+       "  'BigLemonJuice',\n",
+       "  'OrangeJuice',\n",
+       "  'RedSpritzer',\n",
        "  'Snacks',\n",
-       "  'FruitBarForestFruit',\n",
-       "  'CerealBarChocolateBanana',\n",
-       "  'PeanutBits',\n",
-       "  'GetIt',\n",
        "  'Cracker',\n",
-       "  'CerealBarChocolate',\n",
+       "  'PeanutBits',\n",
+       "  'CerealBarChocolateBanana',\n",
+       "  'FruitBarForestFruit',\n",
        "  'NutFruitMix',\n",
+       "  'CerealBarChocolate',\n",
+       "  'GetIt',\n",
        "  'FruitBarApple',\n",
        "  'Fruit',\n",
        "  'Lemon',\n",
        "  'Orange',\n",
+       "  'Container',\n",
+       "  'Tray',\n",
+       "  'Basket',\n",
        "  'Other',\n",
        "  'Trashbag',\n",
        "  'Furniture',\n",
-       "  'Couch',\n",
-       "  'BarTable',\n",
-       "  'Cabinet',\n",
-       "  'HighTable',\n",
-       "  'KitchenTable',\n",
-       "  'Chair',\n",
-       "  'Coathanger',\n",
-       "  'Sofa',\n",
-       "  'TV',\n",
-       "  'Cupboard',\n",
-       "  'KitchenCabinet',\n",
-       "  'SideTable',\n",
-       "  'TVTable',\n",
        "  'Dishwasher',\n",
-       "  'Bed',\n",
-       "  'Desk',\n",
+       "  'Coathanger',\n",
        "  'TrashCan',\n",
-       "  'Sideboard',\n",
-       "  'WhiteDrawer',\n",
-       "  'TrashBin',\n",
-       "  'CoffeeTable',\n",
+       "  'SideTable',\n",
+       "  'Bed',\n",
        "  'Bookcase',\n",
-       "  'Drinks',\n",
-       "  'BigLemonJuice',\n",
-       "  'IsoDrink',\n",
-       "  'RedSpritzer',\n",
-       "  'AppleJuice',\n",
-       "  'OrangeJuice',\n",
-       "  'BigCoke',\n",
-       "  'SparklingWater',\n",
-       "  'BigWater',\n",
-       "  'Milk'],\n",
+       "  'Sofa',\n",
+       "  'WhiteDrawer',\n",
+       "  'Desk',\n",
+       "  'TV',\n",
+       "  'Cabinet',\n",
+       "  'KitchenTable',\n",
+       "  'BarTable',\n",
+       "  'HighTable',\n",
+       "  'Sideboard',\n",
+       "  'Cupboard',\n",
+       "  'Couch',\n",
+       "  'Chair',\n",
+       "  'CoffeeTable',\n",
+       "  'TrashBin',\n",
+       "  'KitchenCabinet',\n",
+       "  'TVTable',\n",
+       "  'CleaningStuff',\n",
+       "  'DishwasherTab',\n",
+       "  'Cloth'],\n",
        " 'Orange': [],\n",
        " 'OrangeJuice': [],\n",
        " 'Other': ['Trashbag'],\n",
@@ -349,20 +420,20 @@
        " 'Plane': [],\n",
        " 'Plate': [],\n",
        " 'RedSpritzer': [],\n",
-       " 'Room': ['Kitchen', 'Hallway', 'LivingRoom', 'Bar', 'Bedroom'],\n",
+       " 'Room': ['Hallway', 'Bar', 'Kitchen', 'LivingRoom', 'Bedroom'],\n",
        " 'Salt': [],\n",
        " 'Sauerkraut': [],\n",
        " 'SeasoningMix': [],\n",
        " 'ShowerGel': [],\n",
        " 'SideTable': [],\n",
        " 'Sideboard': [],\n",
-       " 'Snacks': ['FruitBarForestFruit',\n",
-       "  'CerealBarChocolateBanana',\n",
+       " 'Snacks': ['Cracker',\n",
        "  'PeanutBits',\n",
-       "  'GetIt',\n",
-       "  'Cracker',\n",
-       "  'CerealBarChocolate',\n",
+       "  'CerealBarChocolateBanana',\n",
+       "  'FruitBarForestFruit',\n",
        "  'NutFruitMix',\n",
+       "  'CerealBarChocolate',\n",
+       "  'GetIt',\n",
        "  'FruitBarApple'],\n",
        " 'Soap': [],\n",
        " 'Sofa': [],\n",
@@ -391,7 +462,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "The above examples were all about retrieving information from the TBox, but we can obviously also obtain information from the ABox.\n",
     "\n",
@@ -401,16 +476,20 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['BarTableChair',\n",
-       " 'HighTableChair',\n",
-       " 'KitchenTableChair2',\n",
+       "['KitchenTableChair2',\n",
        " 'RightArmChair',\n",
+       " 'BarTableChair',\n",
        " 'DeskChair',\n",
+       " 'HighTableChair',\n",
        " 'LeftArmChair',\n",
        " 'KitchenTableChair1']"
       ]
@@ -426,7 +505,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "If necessary, it is also possible to retrieve a list of all instances in the ontology regardless of their class. The `get_instances` function provides this functionality."
    ]
@@ -441,106 +524,106 @@
     {
      "data": {
       "text/plain": [
-       "['KitchenEasthWall',\n",
-       " 'KitchenWestWall',\n",
-       " 'KitchenNorthWall',\n",
-       " 'KitchenCabinetTopPlaneRight1',\n",
-       " 'BedroomEasthWall',\n",
+       "['Thomas',\n",
+       " 'Mia',\n",
+       " 'Robert',\n",
+       " 'David',\n",
+       " 'WhiteDrawer',\n",
+       " 'KitchenCabinet',\n",
+       " 'Kitchen',\n",
+       " 'Food',\n",
+       " 'Richard',\n",
+       " 'Joseph',\n",
        " 'KitchenTablePlane',\n",
-       " 'Charles',\n",
+       " 'CupboardPlane3',\n",
+       " 'James',\n",
+       " 'William',\n",
+       " 'Desk',\n",
+       " 'Madison',\n",
+       " 'John',\n",
+       " 'Sophia',\n",
+       " 'KitchenCabinetopPlaneLeft2',\n",
+       " 'Bed',\n",
+       " 'KitchenTableChair2',\n",
+       " 'TVTablePlane',\n",
+       " 'SideTable',\n",
+       " 'BookcasePlane2',\n",
+       " 'LivingRoomSouthhWall',\n",
+       " 'LivingRoomWesthWall',\n",
+       " 'CoffeeTable',\n",
+       " 'Sideboard',\n",
+       " 'Couch',\n",
+       " 'TVTable',\n",
+       " 'LivingRoomNorthWall',\n",
+       " 'KitchenEasthWall',\n",
+       " 'Isabella',\n",
+       " 'BarTableChair',\n",
+       " 'BookcasePlane1',\n",
+       " 'SideboardPlane',\n",
+       " 'KitchenTable',\n",
+       " 'HallwayWesthWall',\n",
+       " 'LeftArmChair',\n",
+       " 'TrashBin',\n",
+       " 'HighTableChair',\n",
+       " 'DeskChair',\n",
+       " 'TrashCan',\n",
+       " 'KitchenTableChair1',\n",
+       " 'BedroomEasthWall',\n",
+       " 'Snacks',\n",
+       " 'BarTable',\n",
+       " 'Bookcase',\n",
+       " 'BedroomNorthWall',\n",
+       " 'Olivia',\n",
        " 'CupboardPlane1',\n",
        " 'RightArmChair',\n",
-       " 'HallwayWesthWall',\n",
        " 'KitchenCabinetTopPlaneRight2',\n",
-       " 'TrashCan',\n",
+       " 'Emma',\n",
+       " 'Michael',\n",
+       " 'KitchenWestWall',\n",
+       " 'Ava',\n",
+       " 'Care',\n",
+       " 'DishwasherPlane',\n",
+       " 'BarSouthWall',\n",
+       " 'KitchenNorthWall',\n",
+       " 'BedroomSouthWall',\n",
+       " 'BarWestWall',\n",
+       " 'KitchenCabinetPlane',\n",
+       " 'Sofa',\n",
        " 'Bar',\n",
+       " 'TV',\n",
+       " 'Fruit',\n",
+       " 'BookcasePlane3',\n",
+       " 'Drinks',\n",
+       " 'KitchenCabinetTopPlaneRight1',\n",
+       " 'HallwayEasthWall',\n",
+       " 'SideTablePlane',\n",
        " 'CupboardPlane2',\n",
-       " 'Madison',\n",
-       " 'LivingRoomWesthWall',\n",
+       " 'WhiteDrawerPlane',\n",
+       " 'Bedroom',\n",
+       " 'LivingRoom',\n",
+       " 'Abigail',\n",
+       " 'HallwayNorthWall',\n",
+       " 'HighTable',\n",
+       " 'BarTablePlane',\n",
+       " 'LivingRoomEastWall',\n",
+       " 'KitchenSouthhWall',\n",
+       " 'CoffeeTablePlane',\n",
+       " 'CleaningStuff',\n",
+       " 'Emily',\n",
+       " 'Hallway',\n",
+       " 'Charles',\n",
+       " 'Dishwasher',\n",
+       " 'KitchenCabinetTopPlaneLeft1',\n",
+       " 'DeskPlane',\n",
+       " 'HighTablePlane',\n",
+       " 'Cabinet',\n",
        " 'Container',\n",
        " 'CabinetPlane',\n",
-       " 'LivingRoomSouthhWall',\n",
-       " 'CoffeeTable',\n",
-       " 'Couch',\n",
-       " 'William',\n",
-       " 'Robert',\n",
-       " 'Cabinet',\n",
-       " 'BookcasePlane2',\n",
-       " 'BarSouthWall',\n",
-       " 'BarTable',\n",
-       " 'Dishwasher',\n",
-       " 'Sofa',\n",
-       " 'Bookcase',\n",
-       " 'Chloe',\n",
-       " 'Isabella',\n",
-       " 'Richard',\n",
-       " 'Sophia',\n",
-       " 'WhiteDrawerPlane',\n",
-       " 'John',\n",
-       " 'WhiteDrawer',\n",
-       " 'LivingRoomNorthWall',\n",
        " 'KitchenStuff',\n",
-       " 'CoffeeTablePlane',\n",
-       " 'Bed',\n",
-       " 'David',\n",
-       " 'BedroomSouthWall',\n",
-       " 'CleaningStuff',\n",
-       " 'Emma',\n",
-       " 'BarTablePlane',\n",
-       " 'KitchenCabinetPlane',\n",
-       " 'Ava',\n",
-       " 'DeskChair',\n",
-       " 'TVTable',\n",
-       " 'Desk',\n",
-       " 'KitchenTableChair1',\n",
-       " 'BookcasePlane1',\n",
-       " 'BarWestWall',\n",
-       " 'SideTablePlane',\n",
-       " 'TrashBin',\n",
-       " 'HighTablePlane',\n",
-       " 'TV',\n",
-       " 'Drinks',\n",
-       " 'SideboardPlane',\n",
-       " 'SideTable',\n",
-       " 'LeftArmChair',\n",
-       " 'Olivia',\n",
-       " 'TVTablePlane',\n",
-       " 'Joseph',\n",
-       " 'BedroomWesthWall',\n",
-       " 'Mia',\n",
-       " 'HighTable',\n",
-       " 'Abigail',\n",
-       " 'DeskPlane',\n",
-       " 'CupboardPlane3',\n",
-       " 'BarNorthWall',\n",
-       " 'KitchenCabinet',\n",
-       " 'Thomas',\n",
-       " 'HallwayNorthWall',\n",
        " 'BarEasthWall',\n",
-       " 'KitchenTableChair2',\n",
-       " 'LivingRoom',\n",
-       " 'LivingRoomEastWall',\n",
-       " 'Bedroom',\n",
-       " 'KitchenTable',\n",
-       " 'Michael',\n",
-       " 'DishwasherPlane',\n",
-       " 'BarTableChair',\n",
-       " 'Sideboard',\n",
-       " 'BedroomNorthWall',\n",
-       " 'KitchenCabinetTopPlaneLeft1',\n",
-       " 'Emily',\n",
-       " 'Care',\n",
-       " 'BookcasePlane3',\n",
-       " 'KitchenSouthhWall',\n",
-       " 'Hallway',\n",
-       " 'HighTableChair',\n",
-       " 'HallwayEasthWall',\n",
-       " 'James',\n",
-       " 'KitchenCabinetopPlaneLeft2',\n",
-       " 'Food',\n",
-       " 'Fruit',\n",
-       " 'Kitchen',\n",
-       " 'Snacks']"
+       " 'Chloe',\n",
+       " 'BedroomWesthWall',\n",
+       " 'BarNorthWall']"
       ]
      },
      "execution_count": 8,
@@ -554,7 +637,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "For locally edited ontologies, the query interface also provides functions for inserting and deleting class assertions: `insert_class_assertion` and `remove_class_assertion` respectively.\n",
     "\n",
@@ -564,7 +651,11 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [],
    "source": [
     "ontology_interface.insert_class_assertion('Cereal', 'CornFlakes')"
@@ -573,7 +664,11 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -592,7 +687,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "Similarly, we can remove `CornFlakes` as an instance of the `Cereal` class as"
    ]
@@ -600,7 +699,11 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [],
    "source": [
     "ontology_interface.remove_class_assertion('Cereal', 'CornFlakes')"
@@ -609,7 +712,11 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -628,7 +735,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "The changes done by the `insert_class_assertion` and `remove_class_assertion` are only applied to the loaded knowledge graph, but are not saved. To actually save them to the ontology file, a call to the `update` function is necessary:"
    ]
@@ -636,7 +747,11 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [],
    "source": [
     "# ontology_interface.update()"
@@ -644,21 +759,33 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "source": [
     "Note that we are not going to call `update` in this example since we are loading the ontology from a non-editable file from a web URL."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "### Retrieving Object Property Data"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "source": [
     "Just as we can obtain a list of all classes, we can also obtain a list of all object properties in the ontology. We can do this using the `get_object_properties` function."
    ]
@@ -667,14 +794,17 @@
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {
-    "scrolled": true
+    "scrolled": true,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['nextTo', 'hasDoor', 'toTheLeftOf', 'toTheRightOf', 'inside', 'connectedTo', 'closeTo', 'above', 'locatedAt', 'defaultLocation', 'below', 'oppositeTo', 'onTopOf', 'canPlaceOn', 'closeToWall']\n"
+      "['onTopOf', 'connectedTo', 'inside', 'closeTo', 'below', 'toTheRightOf', 'above', 'canPlaceOn', 'locatedAt', 'defaultLocation', 'nextTo', 'oppositeTo', 'toTheLeftOf', 'hasDoor', 'closeToWall']\n"
      ]
     }
    ],
@@ -685,7 +815,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "In some cases, obtaining the type of a property is also useful. The following snippet uses the `get_property_domain_range` function to obtain the domain and range of all properties in the ontology."
    ]
@@ -694,27 +828,30 @@
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {
-    "scrolled": true
+    "scrolled": true,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "nextTo: Object -> Object\n",
-      "hasDoor: Furniture -> boolean\n",
-      "toTheLeftOf: Object -> Object\n",
-      "toTheRightOf: Object -> Object\n",
-      "inside: Object -> Object\n",
+      "onTopOf: Object -> Object\n",
       "connectedTo: Room -> Room\n",
+      "inside: Object -> Object\n",
       "closeTo: Object -> Object\n",
+      "below: Object -> Object\n",
+      "toTheRightOf: Object -> Object\n",
       "above: Object -> Object\n",
+      "canPlaceOn: Object -> Plane\n",
       "locatedAt: Object -> Location\n",
       "defaultLocation: Object -> Furniture\n",
-      "below: Object -> Object\n",
+      "nextTo: Object -> Object\n",
       "oppositeTo: Object -> Object\n",
-      "onTopOf: Object -> Object\n",
-      "canPlaceOn: Object -> Plane\n",
+      "toTheLeftOf: Object -> Object\n",
+      "hasDoor: Furniture -> boolean\n",
       "closeToWall: Object -> Wall\n"
      ]
     }
@@ -727,7 +864,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "Given a property, we can also retrieve all of its assertions using the `get_all_subjects_and_objects` function. This function returns a list of pairs in which the first element is the subject and the second element is the object.\n",
     "\n",
@@ -738,34 +879,37 @@
    "cell_type": "code",
    "execution_count": 16,
    "metadata": {
-    "scrolled": false
+    "scrolled": false,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[('HighTable', 'LivingRoom'),\n",
-       " ('WhiteDrawer', 'Kitchen'),\n",
-       " ('Sofa', 'Bar'),\n",
-       " ('KitchenCabinet', 'Kitchen'),\n",
+       "[('CupBoard', 'Bar'),\n",
        " ('SideTable', 'Bedroom'),\n",
+       " ('Sofa', 'Bar'),\n",
        " ('BarTable', 'Bar'),\n",
-       " ('Bed', 'Bedroom'),\n",
-       " ('Bookcase', 'LivingRoom'),\n",
-       " ('CoffeeTable', 'LivingRoom'),\n",
-       " ('RightArmChair', 'LivingRoom'),\n",
-       " ('LeftArmChair', 'LivingRoom'),\n",
-       " ('CoatHanger', 'LivingRoom'),\n",
-       " ('Desk', 'Bedroom'),\n",
-       " ('CupBoard', 'Bar'),\n",
-       " ('TrashBin', 'LivingRoom'),\n",
        " ('KitchenTable', 'Kitchen'),\n",
-       " ('TrashCan', 'Kitchen'),\n",
+       " ('Bed', 'Bedroom'),\n",
+       " ('RightArmChair', 'LivingRoom'),\n",
+       " ('HighTable', 'LivingRoom'),\n",
+       " ('Desk', 'Bedroom'),\n",
        " ('Sideboard', 'LivingRoom'),\n",
-       " ('Dishwasher', 'Kitchen'),\n",
-       " ('Couch', 'LivingRoom'),\n",
+       " ('CoffeeTable', 'LivingRoom'),\n",
+       " ('CoatHanger', 'LivingRoom'),\n",
+       " ('KitchenCabinet', 'Kitchen'),\n",
+       " ('TrashBin', 'LivingRoom'),\n",
+       " ('Bookcase', 'LivingRoom'),\n",
+       " ('TrashCan', 'Kitchen'),\n",
        " ('TVTable', 'LivingRoom'),\n",
-       " ('Cabinet', 'Kitchen')]"
+       " ('LeftArmChair', 'LivingRoom'),\n",
+       " ('Cabinet', 'Kitchen'),\n",
+       " ('Couch', 'LivingRoom'),\n",
+       " ('Dishwasher', 'Kitchen'),\n",
+       " ('WhiteDrawer', 'Kitchen')]"
       ]
      },
      "execution_count": 16,
@@ -779,7 +923,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "We can also retrieve more specific information about the property assertions using the `get_subjects_of` and `get_objects_of` functions.\n",
     "\n",
@@ -789,21 +937,25 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['HighTable',\n",
-       " 'TrashBin',\n",
-       " 'Sideboard',\n",
-       " 'Bookcase',\n",
-       " 'CoffeeTable',\n",
-       " 'RightArmChair',\n",
-       " 'Couch',\n",
-       " 'LeftArmChair',\n",
+       "['Sideboard',\n",
        " 'CoatHanger',\n",
-       " 'TVTable']"
+       " 'CoffeeTable',\n",
+       " 'TrashBin',\n",
+       " 'Bookcase',\n",
+       " 'RightArmChair',\n",
+       " 'TVTable',\n",
+       " 'LeftArmChair',\n",
+       " 'Couch',\n",
+       " 'HighTable']"
       ]
      },
      "execution_count": 17,
@@ -817,15 +969,23 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "Similarly, the `get_objects_of`function returns all objects for a given property and subject. We can for instance get the location of the desk as follows:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
+   "execution_count": 18,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -833,7 +993,7 @@
        "['Bedroom']"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -844,14 +1004,22 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "source": [
     "It should be noted that the `get_objects_of` function returns a list of objects, even though in this case we know that the desk can only be in one place. `get_objects_of` is thus a functional property."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "As in the case of class assertions, we can also insert and remove property assertions from the ontology, using the `insert_property_assertion` and `remove_property_assertion` functions respectively. Both functions get the name of a property and a subject-object pair.\n",
     "\n",
@@ -860,8 +1028,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
+   "execution_count": 19,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [],
    "source": [
     "ontology_interface.insert_property_assertion('hasDoor', ('Bookcase', 'True'))"
@@ -869,8 +1041,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
+   "execution_count": 20,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -878,7 +1054,7 @@
        "['True']"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -889,15 +1065,23 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "In a similar manner, we can also remove this assertion from the ontology:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
+   "execution_count": 21,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [],
    "source": [
     "ontology_interface.remove_property_assertion('hasDoor', ('Bookcase', 'True'))"
@@ -905,8 +1089,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
+   "execution_count": 22,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -914,7 +1102,7 @@
        "[]"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -925,15 +1113,23 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
    "source": [
     "As for class assertions, inserted and removed property assertions are only applied to the loaded knowledge graph. To actually apply save them to the ontology file, we need to call the `update` function (which we are again not doing since we are loading a non-editable ontology from a web URL)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 23,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [],
    "source": [
     "# ontology_interface.update()"
@@ -941,6 +1137,7 @@
   }
  ],
  "metadata": {
+  "celltoolbar": "Slideshow",
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",

--- a/examples/ontology_interface.ipynb
+++ b/examples/ontology_interface.ipynb
@@ -772,6 +772,30 @@
    "cell_type": "markdown",
    "metadata": {
     "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "Changes to the ontology can also be saved to a file using the `export` function, which, instead of overwriting the original ontology file, writes the ontology to a file given as an argument."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# ontology_interface.export('file:///path/to/updated_ontology.owl')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
      "slide_type": "slide"
     }
    },

--- a/examples/ontology_interface.ipynb
+++ b/examples/ontology_interface.ipynb
@@ -112,7 +112,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['WhiteDrawer', 'Cracker', 'Female', 'Fruit', 'Spoon', 'NutFruitMix', 'OrangeJuice', 'HighTable', 'GetIt', 'Object', 'Cupboard', 'Location', 'Food', 'Noodles', 'TVTable', 'CoffeeTable', 'Couch', 'PeanutBits', 'Bar', 'Hallway', 'TrashBin', 'Lemon', 'Sofa', 'Salt', 'TrashCan', 'Wall', 'Bowl', 'CerealBarChocolate', 'Tomatoes', 'AppleJuice', 'Milk', 'SideTable', 'BarTable', 'Bouillon', 'Room', 'Dishwasher', 'FruitBarApple', 'CerealBarChocolateBanana', 'Bookcase', 'Cabinet', 'KitchenCabinet', 'Sauerkraut', 'Bedroom', 'Sideboard', 'Plate', 'Toothpaste', 'Person', 'Coathanger', 'KitchenTable', 'Kitchen', 'Cereal', 'FruitBarForestFruit', 'Knife', 'Other', 'Trashbag', 'Cloth', 'BigCoke', 'KitchenStuff', 'Soap', 'Corn', 'LivingRoom', 'Male', 'BigLemonJuice', 'Fork', 'Snacks', 'DishwasherTab', 'Desk', 'Chair', 'TV', 'RedSpritzer', 'Drinks', 'Bed', 'BigWater', 'IsoDrink', 'Basket', 'Container', 'SparklingWater', 'ShowerGel', 'Plane', 'Pepper', 'Orange', 'Cup', 'Care', 'CleaningStuff', 'Furniture', 'SeasoningMix', 'Tray']\n"
+      "['Food', 'Fruit', 'Noodles', 'Cracker', 'Cloth', 'FruitBarApple', 'PeanutBits', 'CleaningStuff', 'Knife', 'Location', 'Cabinet', 'Hallway', 'Couch', 'Orange', 'NutFruitMix', 'LivingRoom', 'Furniture', 'Bowl', 'Corn', 'Sideboard', 'Bookcase', 'Room', 'BigLemonJuice', 'Cupboard', 'Other', 'Desk', 'Tomatoes', 'Spoon', 'GetIt', 'SeasoningMix', 'Drinks', 'Trashbag', 'Toothpaste', 'Sofa', 'RedSpritzer', 'Wall', 'BarTable', 'Snacks', 'Sauerkraut', 'Person', 'SideTable', 'KitchenCabinet', 'Cup', 'Bar', 'Soap', 'TV', 'TrashBin', 'Male', 'WhiteDrawer', 'Basket', 'TVTable', 'HighTable', 'TrashCan', 'Salt', 'Chair', 'Female', 'Plane', 'Bedroom', 'KitchenTable', 'SparklingWater', 'BigCoke', 'Pepper', 'Care', 'IsoDrink', 'Lemon', 'AppleJuice', 'OrangeJuice', 'Bouillon', 'Plate', 'ShowerGel', 'Tray', 'CoffeeTable', 'CerealBarChocolate', 'Kitchen', 'Fork', 'Object', 'DishwasherTab', 'Coathanger', 'CerealBarChocolateBanana', 'Bed', 'BigWater', 'KitchenStuff', 'Dishwasher', 'FruitBarForestFruit', 'Container', 'Cereal', 'Milk']\n"
      ]
     }
    ],
@@ -193,7 +193,7 @@
     {
      "data": {
       "text/plain": [
-       "['KitchenStuff', 'Plate', 'Cup', 'Bowl', 'Spoon', 'Fork', 'Knife']"
+       "['KitchenStuff', 'Spoon', 'Plate', 'Knife', 'Bowl', 'Fork', 'Cup']"
       ]
      },
      "execution_count": 5,
@@ -252,7 +252,7 @@
        " 'Bouillon': [],\n",
        " 'Bowl': [],\n",
        " 'Cabinet': [],\n",
-       " 'Care': ['Toothpaste', 'Soap', 'ShowerGel'],\n",
+       " 'Care': ['Soap', 'Toothpaste', 'ShowerGel'],\n",
        " 'Cereal': [],\n",
        " 'CerealBarChocolate': [],\n",
        " 'CerealBarChocolateBanana': [],\n",
@@ -261,7 +261,7 @@
        " 'Cloth': [],\n",
        " 'Coathanger': [],\n",
        " 'CoffeeTable': [],\n",
-       " 'Container': ['Tray', 'Basket'],\n",
+       " 'Container': ['Basket', 'Tray'],\n",
        " 'Corn': [],\n",
        " 'Couch': [],\n",
        " 'Cracker': [],\n",
@@ -271,146 +271,146 @@
        " 'Dishwasher': [],\n",
        " 'DishwasherTab': [],\n",
        " 'Drinks': ['AppleJuice',\n",
+       "  'BigCoke',\n",
+       "  'RedSpritzer',\n",
+       "  'Milk',\n",
        "  'SparklingWater',\n",
        "  'IsoDrink',\n",
        "  'BigWater',\n",
-       "  'Milk',\n",
-       "  'BigCoke',\n",
-       "  'BigLemonJuice',\n",
        "  'OrangeJuice',\n",
-       "  'RedSpritzer'],\n",
+       "  'BigLemonJuice'],\n",
        " 'Female': [],\n",
-       " 'Food': ['Cereal',\n",
-       "  'Bouillon',\n",
-       "  'Noodles',\n",
-       "  'SeasoningMix',\n",
-       "  'Tomatoes',\n",
+       " 'Food': ['Bouillon',\n",
        "  'Corn',\n",
        "  'Salt',\n",
-       "  'Pepper',\n",
-       "  'Sauerkraut'],\n",
+       "  'SeasoningMix',\n",
+       "  'Sauerkraut',\n",
+       "  'Cereal',\n",
+       "  'Noodles',\n",
+       "  'Tomatoes',\n",
+       "  'Pepper'],\n",
        " 'Fork': [],\n",
-       " 'Fruit': ['Lemon', 'Orange'],\n",
+       " 'Fruit': ['Orange', 'Lemon'],\n",
        " 'FruitBarApple': [],\n",
        " 'FruitBarForestFruit': [],\n",
-       " 'Furniture': ['Dishwasher',\n",
-       "  'Coathanger',\n",
-       "  'TrashCan',\n",
-       "  'SideTable',\n",
-       "  'Bed',\n",
-       "  'Bookcase',\n",
-       "  'Sofa',\n",
-       "  'WhiteDrawer',\n",
-       "  'Desk',\n",
-       "  'TV',\n",
-       "  'Cabinet',\n",
-       "  'KitchenTable',\n",
-       "  'BarTable',\n",
-       "  'HighTable',\n",
-       "  'Sideboard',\n",
-       "  'Cupboard',\n",
-       "  'Couch',\n",
-       "  'Chair',\n",
+       " 'Furniture': ['SideTable',\n",
+       "  'Dishwasher',\n",
        "  'CoffeeTable',\n",
+       "  'HighTable',\n",
+       "  'TrashCan',\n",
+       "  'Sideboard',\n",
+       "  'Chair',\n",
        "  'TrashBin',\n",
+       "  'Coathanger',\n",
+       "  'Bed',\n",
+       "  'Desk',\n",
+       "  'BarTable',\n",
+       "  'WhiteDrawer',\n",
+       "  'Cupboard',\n",
+       "  'KitchenTable',\n",
+       "  'Cabinet',\n",
+       "  'Sofa',\n",
+       "  'TVTable',\n",
+       "  'Couch',\n",
+       "  'TV',\n",
        "  'KitchenCabinet',\n",
-       "  'TVTable'],\n",
+       "  'Bookcase'],\n",
        " 'GetIt': [],\n",
        " 'Hallway': [],\n",
        " 'HighTable': [],\n",
        " 'IsoDrink': [],\n",
        " 'Kitchen': [],\n",
        " 'KitchenCabinet': [],\n",
-       " 'KitchenStuff': ['Plate', 'Cup', 'Bowl', 'Spoon', 'Fork', 'Knife'],\n",
+       " 'KitchenStuff': ['Spoon', 'Plate', 'Knife', 'Bowl', 'Fork', 'Cup'],\n",
        " 'KitchenTable': [],\n",
        " 'Knife': [],\n",
        " 'Lemon': [],\n",
        " 'LivingRoom': [],\n",
        " 'Location': ['Wall',\n",
        "  'Room',\n",
-       "  'Hallway',\n",
-       "  'Bar',\n",
        "  'Kitchen',\n",
        "  'LivingRoom',\n",
+       "  'Bar',\n",
+       "  'Hallway',\n",
        "  'Bedroom'],\n",
        " 'Male': [],\n",
        " 'Milk': [],\n",
        " 'Noodles': [],\n",
        " 'NutFruitMix': [],\n",
-       " 'Object': ['Care',\n",
-       "  'Toothpaste',\n",
-       "  'Soap',\n",
-       "  'ShowerGel',\n",
-       "  'KitchenStuff',\n",
-       "  'Plate',\n",
-       "  'Cup',\n",
-       "  'Bowl',\n",
-       "  'Spoon',\n",
-       "  'Fork',\n",
-       "  'Knife',\n",
-       "  'Food',\n",
-       "  'Cereal',\n",
+       " 'Object': ['Food',\n",
        "  'Bouillon',\n",
-       "  'Noodles',\n",
-       "  'SeasoningMix',\n",
-       "  'Tomatoes',\n",
        "  'Corn',\n",
        "  'Salt',\n",
-       "  'Pepper',\n",
+       "  'SeasoningMix',\n",
        "  'Sauerkraut',\n",
+       "  'Cereal',\n",
+       "  'Noodles',\n",
+       "  'Tomatoes',\n",
+       "  'Pepper',\n",
        "  'Drinks',\n",
        "  'AppleJuice',\n",
+       "  'BigCoke',\n",
+       "  'RedSpritzer',\n",
+       "  'Milk',\n",
        "  'SparklingWater',\n",
        "  'IsoDrink',\n",
        "  'BigWater',\n",
-       "  'Milk',\n",
-       "  'BigCoke',\n",
-       "  'BigLemonJuice',\n",
        "  'OrangeJuice',\n",
-       "  'RedSpritzer',\n",
+       "  'BigLemonJuice',\n",
        "  'Snacks',\n",
-       "  'Cracker',\n",
-       "  'PeanutBits',\n",
-       "  'CerealBarChocolateBanana',\n",
-       "  'FruitBarForestFruit',\n",
-       "  'NutFruitMix',\n",
-       "  'CerealBarChocolate',\n",
        "  'GetIt',\n",
+       "  'CerealBarChocolate',\n",
+       "  'FruitBarForestFruit',\n",
        "  'FruitBarApple',\n",
-       "  'Fruit',\n",
-       "  'Lemon',\n",
-       "  'Orange',\n",
+       "  'PeanutBits',\n",
+       "  'NutFruitMix',\n",
+       "  'CerealBarChocolateBanana',\n",
+       "  'Cracker',\n",
        "  'Container',\n",
-       "  'Tray',\n",
        "  'Basket',\n",
+       "  'Tray',\n",
+       "  'KitchenStuff',\n",
+       "  'Spoon',\n",
+       "  'Plate',\n",
+       "  'Knife',\n",
+       "  'Bowl',\n",
+       "  'Fork',\n",
+       "  'Cup',\n",
        "  'Other',\n",
        "  'Trashbag',\n",
-       "  'Furniture',\n",
-       "  'Dishwasher',\n",
-       "  'Coathanger',\n",
-       "  'TrashCan',\n",
-       "  'SideTable',\n",
-       "  'Bed',\n",
-       "  'Bookcase',\n",
-       "  'Sofa',\n",
-       "  'WhiteDrawer',\n",
-       "  'Desk',\n",
-       "  'TV',\n",
-       "  'Cabinet',\n",
-       "  'KitchenTable',\n",
-       "  'BarTable',\n",
-       "  'HighTable',\n",
-       "  'Sideboard',\n",
-       "  'Cupboard',\n",
-       "  'Couch',\n",
-       "  'Chair',\n",
-       "  'CoffeeTable',\n",
-       "  'TrashBin',\n",
-       "  'KitchenCabinet',\n",
-       "  'TVTable',\n",
+       "  'Fruit',\n",
+       "  'Orange',\n",
+       "  'Lemon',\n",
+       "  'Care',\n",
+       "  'Soap',\n",
+       "  'Toothpaste',\n",
+       "  'ShowerGel',\n",
        "  'CleaningStuff',\n",
        "  'DishwasherTab',\n",
-       "  'Cloth'],\n",
+       "  'Cloth',\n",
+       "  'Furniture',\n",
+       "  'SideTable',\n",
+       "  'Dishwasher',\n",
+       "  'CoffeeTable',\n",
+       "  'HighTable',\n",
+       "  'TrashCan',\n",
+       "  'Sideboard',\n",
+       "  'Chair',\n",
+       "  'TrashBin',\n",
+       "  'Coathanger',\n",
+       "  'Bed',\n",
+       "  'Desk',\n",
+       "  'BarTable',\n",
+       "  'WhiteDrawer',\n",
+       "  'Cupboard',\n",
+       "  'KitchenTable',\n",
+       "  'Cabinet',\n",
+       "  'Sofa',\n",
+       "  'TVTable',\n",
+       "  'Couch',\n",
+       "  'TV',\n",
+       "  'KitchenCabinet',\n",
+       "  'Bookcase'],\n",
        " 'Orange': [],\n",
        " 'OrangeJuice': [],\n",
        " 'Other': ['Trashbag'],\n",
@@ -420,21 +420,21 @@
        " 'Plane': [],\n",
        " 'Plate': [],\n",
        " 'RedSpritzer': [],\n",
-       " 'Room': ['Hallway', 'Bar', 'Kitchen', 'LivingRoom', 'Bedroom'],\n",
+       " 'Room': ['Kitchen', 'LivingRoom', 'Bar', 'Hallway', 'Bedroom'],\n",
        " 'Salt': [],\n",
        " 'Sauerkraut': [],\n",
        " 'SeasoningMix': [],\n",
        " 'ShowerGel': [],\n",
        " 'SideTable': [],\n",
        " 'Sideboard': [],\n",
-       " 'Snacks': ['Cracker',\n",
-       "  'PeanutBits',\n",
-       "  'CerealBarChocolateBanana',\n",
-       "  'FruitBarForestFruit',\n",
-       "  'NutFruitMix',\n",
+       " 'Snacks': ['GetIt',\n",
        "  'CerealBarChocolate',\n",
-       "  'GetIt',\n",
-       "  'FruitBarApple'],\n",
+       "  'FruitBarForestFruit',\n",
+       "  'FruitBarApple',\n",
+       "  'PeanutBits',\n",
+       "  'NutFruitMix',\n",
+       "  'CerealBarChocolateBanana',\n",
+       "  'Cracker'],\n",
        " 'Soap': [],\n",
        " 'Sofa': [],\n",
        " 'SparklingWater': [],\n",
@@ -468,9 +468,7 @@
     }
    },
    "source": [
-    "The above examples were all about retrieving information from the TBox, but we can obviously also obtain information from the ABox.\n",
-    "\n",
-    "To retrieve all instances of a given class, we can use the `get_instances_of` function, which returns a list with the names of all instances. The following examples illustrates this function by reading out all instances of class `Chair`."
+    "The interface also has a utility function `is_class`, which checks whether a given class exists in the ontology."
    ]
   },
   {
@@ -481,20 +479,47 @@
      "slide_type": "fragment"
     }
    },
+   "outputs": [],
+   "source": [
+    "assert ontology_interface.is_class('Basket')\n",
+    "assert not ontology_interface.is_class('Truck')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "The above examples were all about retrieving information from the TBox, but we can obviously also obtain information from the ABox.\n",
+    "\n",
+    "To retrieve all instances of a given class, we can use the `get_instances_of` function, which returns a list with the names of all instances. The following example illustrates this function by reading out all instances of class `Chair`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['KitchenTableChair2',\n",
-       " 'RightArmChair',\n",
-       " 'BarTableChair',\n",
+       "['RightArmChair',\n",
        " 'DeskChair',\n",
+       " 'KitchenTableChair1',\n",
+       " 'KitchenTableChair2',\n",
+       " 'BarTableChair',\n",
        " 'HighTableChair',\n",
-       " 'LeftArmChair',\n",
-       " 'KitchenTableChair1']"
+       " 'LeftArmChair']"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -516,117 +541,120 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {
-    "scrolled": true
+    "scrolled": true,
+    "slideshow": {
+     "slide_type": "fragment"
+    }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['Thomas',\n",
-       " 'Mia',\n",
-       " 'Robert',\n",
-       " 'David',\n",
-       " 'WhiteDrawer',\n",
-       " 'KitchenCabinet',\n",
-       " 'Kitchen',\n",
-       " 'Food',\n",
-       " 'Richard',\n",
-       " 'Joseph',\n",
-       " 'KitchenTablePlane',\n",
-       " 'CupboardPlane3',\n",
-       " 'James',\n",
-       " 'William',\n",
-       " 'Desk',\n",
-       " 'Madison',\n",
-       " 'John',\n",
-       " 'Sophia',\n",
-       " 'KitchenCabinetopPlaneLeft2',\n",
-       " 'Bed',\n",
-       " 'KitchenTableChair2',\n",
-       " 'TVTablePlane',\n",
-       " 'SideTable',\n",
-       " 'BookcasePlane2',\n",
-       " 'LivingRoomSouthhWall',\n",
-       " 'LivingRoomWesthWall',\n",
-       " 'CoffeeTable',\n",
-       " 'Sideboard',\n",
-       " 'Couch',\n",
-       " 'TVTable',\n",
-       " 'LivingRoomNorthWall',\n",
-       " 'KitchenEasthWall',\n",
-       " 'Isabella',\n",
-       " 'BarTableChair',\n",
+       "['Emily',\n",
        " 'BookcasePlane1',\n",
-       " 'SideboardPlane',\n",
-       " 'KitchenTable',\n",
-       " 'HallwayWesthWall',\n",
-       " 'LeftArmChair',\n",
-       " 'TrashBin',\n",
-       " 'HighTableChair',\n",
-       " 'DeskChair',\n",
-       " 'TrashCan',\n",
-       " 'KitchenTableChair1',\n",
-       " 'BedroomEasthWall',\n",
-       " 'Snacks',\n",
-       " 'BarTable',\n",
-       " 'Bookcase',\n",
        " 'BedroomNorthWall',\n",
-       " 'Olivia',\n",
-       " 'CupboardPlane1',\n",
-       " 'RightArmChair',\n",
+       " 'KitchenNorthWall',\n",
+       " 'David',\n",
+       " 'HighTablePlane',\n",
+       " 'TrashCan',\n",
+       " 'BarEasthWall',\n",
        " 'KitchenCabinetTopPlaneRight2',\n",
-       " 'Emma',\n",
+       " 'Robert',\n",
+       " 'Thomas',\n",
+       " 'CupboardPlane1',\n",
+       " 'BarSouthWall',\n",
        " 'Michael',\n",
+       " 'BookcasePlane2',\n",
+       " 'BarTableChair',\n",
+       " 'KitchenCabinetPlane',\n",
+       " 'KitchenCabinetTopPlaneLeft1',\n",
+       " 'BedroomWesthWall',\n",
+       " 'Olivia',\n",
+       " 'HallwayNorthWall',\n",
+       " 'Cabinet',\n",
+       " 'KitchenTableChair1',\n",
+       " 'HallwayWesthWall',\n",
+       " 'BookcasePlane3',\n",
+       " 'Madison',\n",
+       " 'Snacks',\n",
+       " 'BarWestWall',\n",
+       " 'SideTable',\n",
+       " 'Richard',\n",
+       " 'CleaningStuff',\n",
+       " 'Charles',\n",
        " 'KitchenWestWall',\n",
+       " 'KitchenCabinetopPlaneLeft2',\n",
+       " 'CabinetPlane',\n",
+       " 'LivingRoom',\n",
+       " 'William',\n",
+       " 'TrashBin',\n",
+       " 'James',\n",
+       " 'LivingRoomNorthWall',\n",
+       " 'CupboardPlane2',\n",
+       " 'BedroomSouthWall',\n",
+       " 'HighTable',\n",
+       " 'Sophia',\n",
+       " 'Emma',\n",
+       " 'Bar',\n",
+       " 'Bookcase',\n",
+       " 'KitchenStuff',\n",
+       " 'KitchenCabinet',\n",
+       " 'Dishwasher',\n",
+       " 'KitchenTable',\n",
+       " 'Couch',\n",
+       " 'CoffeeTablePlane',\n",
+       " 'LivingRoomEastWall',\n",
+       " 'Chloe',\n",
        " 'Ava',\n",
+       " 'Container',\n",
+       " 'Isabella',\n",
+       " 'KitchenTablePlane',\n",
+       " 'HallwayEasthWall',\n",
+       " 'LivingRoomWesthWall',\n",
+       " 'HighTableChair',\n",
+       " 'DeskPlane',\n",
+       " 'Kitchen',\n",
+       " 'KitchenCabinetTopPlaneRight1',\n",
+       " 'TVTable',\n",
+       " 'Fruit',\n",
+       " 'Abigail',\n",
+       " 'LivingRoomSouthhWall',\n",
+       " 'Drinks',\n",
+       " 'Mia',\n",
+       " 'SideboardPlane',\n",
+       " 'TV',\n",
+       " 'CupboardPlane3',\n",
        " 'Care',\n",
        " 'DishwasherPlane',\n",
-       " 'BarSouthWall',\n",
-       " 'KitchenNorthWall',\n",
-       " 'BedroomSouthWall',\n",
-       " 'BarWestWall',\n",
-       " 'KitchenCabinetPlane',\n",
-       " 'Sofa',\n",
-       " 'Bar',\n",
-       " 'TV',\n",
-       " 'Fruit',\n",
-       " 'BookcasePlane3',\n",
-       " 'Drinks',\n",
-       " 'KitchenCabinetTopPlaneRight1',\n",
-       " 'HallwayEasthWall',\n",
-       " 'SideTablePlane',\n",
-       " 'CupboardPlane2',\n",
-       " 'WhiteDrawerPlane',\n",
-       " 'Bedroom',\n",
-       " 'LivingRoom',\n",
-       " 'Abigail',\n",
-       " 'HallwayNorthWall',\n",
-       " 'HighTable',\n",
+       " 'Bed',\n",
        " 'BarTablePlane',\n",
-       " 'LivingRoomEastWall',\n",
        " 'KitchenSouthhWall',\n",
-       " 'CoffeeTablePlane',\n",
-       " 'CleaningStuff',\n",
-       " 'Emily',\n",
        " 'Hallway',\n",
-       " 'Charles',\n",
-       " 'Dishwasher',\n",
-       " 'KitchenCabinetTopPlaneLeft1',\n",
-       " 'DeskPlane',\n",
-       " 'HighTablePlane',\n",
-       " 'Cabinet',\n",
-       " 'Container',\n",
-       " 'CabinetPlane',\n",
-       " 'KitchenStuff',\n",
-       " 'BarEasthWall',\n",
-       " 'Chloe',\n",
-       " 'BedroomWesthWall',\n",
-       " 'BarNorthWall']"
+       " 'Sideboard',\n",
+       " 'CoffeeTable',\n",
+       " 'WhiteDrawer',\n",
+       " 'DeskChair',\n",
+       " 'WhiteDrawerPlane',\n",
+       " 'SideTablePlane',\n",
+       " 'BarNorthWall',\n",
+       " 'TVTablePlane',\n",
+       " 'BarTable',\n",
+       " 'KitchenEasthWall',\n",
+       " 'Bedroom',\n",
+       " 'Desk',\n",
+       " 'BedroomEasthWall',\n",
+       " 'Food',\n",
+       " 'Sofa',\n",
+       " 'KitchenTableChair2',\n",
+       " 'LeftArmChair',\n",
+       " 'John',\n",
+       " 'Joseph',\n",
+       " 'RightArmChair']"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -643,22 +671,7 @@
     }
    },
    "source": [
-    "For locally edited ontologies, the query interface also provides functions for inserting and deleting class assertions: `insert_class_assertion` and `remove_class_assertion` respectively.\n",
-    "\n",
-    "For instance, we can insert `CornFlakes` as an instance of the `Cereal` class as follows:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "ontology_interface.insert_class_assertion('Cereal', 'CornFlakes')"
+    "To check if a given instance exists in the ontology, the `is_instance` function can be used."
    ]
   },
   {
@@ -669,31 +682,21 @@
      "slide_type": "fragment"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['CornFlakes']"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "ontology_interface.get_instances_of('Cereal')"
+    "assert ontology_interface.is_instance('KitchenTableChair1')\n",
+    "assert not ontology_interface.is_instance('MyBike')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
     "slideshow": {
-     "slide_type": "slide"
+     "slide_type": "fragment"
     }
    },
    "source": [
-    "Similarly, we can remove `CornFlakes` as an instance of the `Cereal` class as"
+    "A similar function - `is_instance_of` - checks whether a certain individual is an instance of a given class."
    ]
   },
   {
@@ -706,7 +709,41 @@
    },
    "outputs": [],
    "source": [
-    "ontology_interface.remove_class_assertion('Cereal', 'CornFlakes')"
+    "assert ontology_interface.is_instance_of('KitchenTableChair2', 'Chair')\n",
+    "assert not ontology_interface.is_instance_of('KitchenTableChair2', 'Bed')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "### Inserting and Removing Class Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "For locally edited ontologies, the query interface also provides functions for inserting and deleting classes and class assertions: `insert_class_definition` and `remove_class_definition` for classes, and `insert_class_assertion` and `remove_class_assertion` for class assertions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "We can insert a new class `Tea` as a subclass of `Drinks` as follows:"
    ]
   },
   {
@@ -717,20 +754,95 @@
      "slide_type": "fragment"
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[]"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "ontology_interface.get_instances_of('Cereal')"
+    "ontology_interface.insert_class_definition('Tea', ['Drinks'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "The class `Tea` can also be removed from the ontology as"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ontology_interface.remove_class_definition('Tea')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "It should be noted that removing a class also removes:\n",
+    "* all assertions of the class\n",
+    "* all properties that have the class as domain or range\n",
+    "* all assertions of those properties"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "Regarding assertions, we can insert `CornFlakes` as an instance of the `Cereal` class as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ontology_interface.insert_class_assertion('Cereal', 'CornFlakes')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "Similarly, we can remove `CornFlakes` as an instance of the `Cereal` class as"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ontology_interface.remove_class_assertion('Cereal', 'CornFlakes')"
    ]
   },
   {
@@ -746,7 +858,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
@@ -781,7 +893,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
@@ -816,7 +928,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 18,
    "metadata": {
     "scrolled": true,
     "slideshow": {
@@ -828,7 +940,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['onTopOf', 'connectedTo', 'inside', 'closeTo', 'below', 'toTheRightOf', 'above', 'canPlaceOn', 'locatedAt', 'defaultLocation', 'nextTo', 'oppositeTo', 'toTheLeftOf', 'hasDoor', 'closeToWall']\n"
+      "['inside', 'toTheRightOf', 'toTheLeftOf', 'hasDoor', 'closeTo', 'above', 'onTopOf', 'canPlaceOn', 'defaultLocation', 'connectedTo', 'locatedAt', 'closeToWall', 'nextTo', 'oppositeTo', 'below']\n"
      ]
     }
    ],
@@ -841,16 +953,41 @@
    "cell_type": "markdown",
    "metadata": {
     "slideshow": {
-     "slide_type": "slide"
+     "slide_type": "fragment"
     }
    },
    "source": [
-    "In some cases, obtaining the type of a property is also useful. The following snippet uses the `get_property_domain_range` function to obtain the domain and range of all properties in the ontology."
+    "To check if a given property exists in the ontology, the `is_property` function can be used."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 19,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "assert ontology_interface.is_property('nextTo')\n",
+    "assert not ontology_interface.is_property('canFly')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "In some cases, obtaining the domain and range of a property is also useful. The following snippet uses the `get_property_domain_range` function to obtain the domain and range of all properties in the ontology."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
    "metadata": {
     "scrolled": true,
     "slideshow": {
@@ -862,21 +999,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "onTopOf: Object -> Object\n",
-      "connectedTo: Room -> Room\n",
       "inside: Object -> Object\n",
-      "closeTo: Object -> Object\n",
-      "below: Object -> Object\n",
       "toTheRightOf: Object -> Object\n",
-      "above: Object -> Object\n",
-      "canPlaceOn: Object -> Plane\n",
-      "locatedAt: Object -> Location\n",
-      "defaultLocation: Object -> Furniture\n",
-      "nextTo: Object -> Object\n",
-      "oppositeTo: Object -> Object\n",
       "toTheLeftOf: Object -> Object\n",
       "hasDoor: Furniture -> boolean\n",
-      "closeToWall: Object -> Wall\n"
+      "closeTo: Object -> Object\n",
+      "above: Object -> Object\n",
+      "onTopOf: Object -> Object\n",
+      "canPlaceOn: Object -> Plane\n",
+      "defaultLocation: Object -> Furniture\n",
+      "connectedTo: Room -> Room\n",
+      "locatedAt: Object -> Location\n",
+      "closeToWall: Object -> Wall\n",
+      "nextTo: Object -> Object\n",
+      "oppositeTo: Object -> Object\n",
+      "below: Object -> Object\n"
      ]
     }
    ],
@@ -894,6 +1031,76 @@
     }
    },
    "source": [
+    "The `get_associated_properties` function allows retrieving properties that are related through a given class, namely properties that have the class either as domain or as range. For example, we can obtain all properties that have `Furniture` as domain or range as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['hasDoor', 'defaultLocation']"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ontology_interface.get_associated_properties('Furniture')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "The interface also allows obtaining the types that are defined for a given property through the `get_property_types` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['FunctionalProperty', 'ObjectProperty']"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ontology_interface.get_property_types('defaultLocation')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
     "Given a property, we can also retrieve all of its assertions using the `get_all_subjects_and_objects` function. This function returns a list of pairs in which the first element is the subject and the second element is the object.\n",
     "\n",
     "The following example returns the locations of various furniture items in the apartment."
@@ -901,7 +1108,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 23,
    "metadata": {
     "scrolled": false,
     "slideshow": {
@@ -912,31 +1119,31 @@
     {
      "data": {
       "text/plain": [
-       "[('CupBoard', 'Bar'),\n",
-       " ('SideTable', 'Bedroom'),\n",
-       " ('Sofa', 'Bar'),\n",
-       " ('BarTable', 'Bar'),\n",
-       " ('KitchenTable', 'Kitchen'),\n",
-       " ('Bed', 'Bedroom'),\n",
-       " ('RightArmChair', 'LivingRoom'),\n",
-       " ('HighTable', 'LivingRoom'),\n",
-       " ('Desk', 'Bedroom'),\n",
-       " ('Sideboard', 'LivingRoom'),\n",
+       "[('Bookcase', 'LivingRoom'),\n",
        " ('CoffeeTable', 'LivingRoom'),\n",
-       " ('CoatHanger', 'LivingRoom'),\n",
-       " ('KitchenCabinet', 'Kitchen'),\n",
-       " ('TrashBin', 'LivingRoom'),\n",
-       " ('Bookcase', 'LivingRoom'),\n",
-       " ('TrashCan', 'Kitchen'),\n",
-       " ('TVTable', 'LivingRoom'),\n",
-       " ('LeftArmChair', 'LivingRoom'),\n",
        " ('Cabinet', 'Kitchen'),\n",
-       " ('Couch', 'LivingRoom'),\n",
+       " ('Bed', 'Bedroom'),\n",
+       " ('Sideboard', 'LivingRoom'),\n",
+       " ('HighTable', 'LivingRoom'),\n",
+       " ('KitchenCabinet', 'Kitchen'),\n",
+       " ('WhiteDrawer', 'Kitchen'),\n",
+       " ('BarTable', 'Bar'),\n",
+       " ('LeftArmChair', 'LivingRoom'),\n",
+       " ('SideTable', 'Bedroom'),\n",
+       " ('TrashBin', 'LivingRoom'),\n",
+       " ('Desk', 'Bedroom'),\n",
+       " ('TVTable', 'LivingRoom'),\n",
+       " ('RightArmChair', 'LivingRoom'),\n",
+       " ('CoatHanger', 'LivingRoom'),\n",
        " ('Dishwasher', 'Kitchen'),\n",
-       " ('WhiteDrawer', 'Kitchen')]"
+       " ('KitchenTable', 'Kitchen'),\n",
+       " ('Couch', 'LivingRoom'),\n",
+       " ('CupBoard', 'Bar'),\n",
+       " ('TrashCan', 'Kitchen'),\n",
+       " ('Sofa', 'Bar')]"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -960,7 +1167,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 24,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
@@ -970,19 +1177,19 @@
     {
      "data": {
       "text/plain": [
-       "['Sideboard',\n",
-       " 'CoatHanger',\n",
+       "['Bookcase',\n",
        " 'CoffeeTable',\n",
-       " 'TrashBin',\n",
-       " 'Bookcase',\n",
-       " 'RightArmChair',\n",
        " 'TVTable',\n",
-       " 'LeftArmChair',\n",
+       " 'Sideboard',\n",
+       " 'RightArmChair',\n",
+       " 'CoatHanger',\n",
+       " 'HighTable',\n",
        " 'Couch',\n",
-       " 'HighTable']"
+       " 'LeftArmChair',\n",
+       " 'TrashBin']"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1004,7 +1211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 25,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
@@ -1017,7 +1224,7 @@
        "['Bedroom']"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1045,14 +1252,93 @@
     }
    },
    "source": [
-    "As in the case of class assertions, we can also insert and remove property assertions from the ontology, using the `insert_property_assertion` and `remove_property_assertion` functions respectively. Both functions get the name of a property and a subject-object pair.\n",
-    "\n",
-    "We can for instance assert that the bookcase has a door as"
+    "### Inserting and Removing Property Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "As in the case of classes, we can also insert and remove properties as well as property assertions. This can be done using the `insert_property_definition` and `remove_property_definition` functions for properties, and `insert_property_assertion` and `remove_property_assertion` functions for property assertions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "Let us for instance insert a new property that specifies the location at which an objects needs to be disposed of. This is thus a functional property for which `Object` is the domain and `Location` is the range."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 26,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ontology_interface.insert_property_definition('disposeAt', 'Object', 'Location', prop_type='FunctionalProperty')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "We can remove the `disposeAt` property from the ontology as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ontology_interface.remove_property_definition('disposeAt')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "fragment"
+    }
+   },
+   "source": [
+    "It should be noted that removing a property also removes all assertions of that property in the ontology."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "The functions for inserting and removing property assertions both get the name of a property and a subject-object pair. We can for instance assert that the bookcase has a door as"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
@@ -1064,34 +1350,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['True']"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ontology_interface.get_objects_of('hasDoor', 'Bookcase')"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "slideshow": {
-     "slide_type": "slide"
+     "slide_type": "fragment"
     }
    },
    "source": [
@@ -1100,7 +1362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 29,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"
@@ -1109,30 +1371,6 @@
    "outputs": [],
    "source": [
     "ontology_interface.remove_property_assertion('hasDoor', ('Bookcase', 'True'))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {
-    "slideshow": {
-     "slide_type": "fragment"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[]"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ontology_interface.get_objects_of('hasDoor', 'Bookcase')"
    ]
   },
   {
@@ -1148,7 +1386,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 30,
    "metadata": {
     "slideshow": {
      "slide_type": "fragment"

--- a/examples/ontology_interface.ipynb
+++ b/examples/ontology_interface.ipynb
@@ -776,6 +776,168 @@
    "source": [
     "ontology_interface.get_all_subjects_and_objects('locatedAt')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also retrieve more specific information about the property assertions using the `get_subjects_of` and `get_objects_of` functions.\n",
+    "\n",
+    "The `get_subjects_of` function returns all subjects for a given property and object. For example, we can retrieve a list of all items located in the living room using as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['HighTable',\n",
+       " 'TrashBin',\n",
+       " 'Sideboard',\n",
+       " 'Bookcase',\n",
+       " 'CoffeeTable',\n",
+       " 'RightArmChair',\n",
+       " 'Couch',\n",
+       " 'LeftArmChair',\n",
+       " 'CoatHanger',\n",
+       " 'TVTable']"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ontology_interface.get_subjects_of('locatedAt', 'LivingRoom')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similarly, the `get_objects_of`function returns all objects for a given property and subject. We can for instance get the location of the desk as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['Bedroom']"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ontology_interface.get_objects_of('locatedAt', 'Desk')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It should be noted that the `get_objects_of` function returns a list of objects, even though in this case we know that the desk can only be in one place. `get_objects_of` is thus a functional property."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As in the case of class assertions, we can also insert and remove property assertions from the ontology, using the `insert_property_assertion` and `remove_property_assertion` functions respectively. Both functions get the name of a property and a subject-object pair.\n",
+    "\n",
+    "We can for instance assert that the bookcase has a door as"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ontology_interface.insert_property_assertion('hasDoor', ('Bookcase', 'True'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['True']"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ontology_interface.get_objects_of('hasDoor', 'Bookcase')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In a similar manner, we can also remove this assertion from the ontology:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ontology_interface.remove_property_assertion('hasDoor', ('Bookcase', 'True'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ontology_interface.get_objects_of('hasDoor', 'Bookcase')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As for class assertions, inserted and removed property assertions are only applied to the loaded knowledge graph. To actually apply save them to the ontology file, we need to call the `update` function (which we are again not doing since we are loading a non-editable ontology from a web URL)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ontology_interface.update()"
+   ]
   }
  ],
  "metadata": {

--- a/examples/ontology_interface.ipynb
+++ b/examples/ontology_interface.ipynb
@@ -63,12 +63,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The interface allows retrieving various aspects from the TBox. For instance, we can retrieve all classes in the ontology using the `get_classes` function:"
+    "The interface allows retrieving various class-related aspects from the TBox. For instance, we can obtain all classes in the ontology using the `get_classes` function:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 3,
    "metadata": {
     "scrolled": true
    },
@@ -77,7 +77,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['Sofa', 'Bedroom', 'Person', 'Milk', 'Container', 'Snacks', 'Spoon', 'Kitchen', 'KitchenCabinet', 'Cup', 'Cupboard', 'ShowerGel', 'Fruit', 'Coathanger', 'TVTable', 'DishwasherTab', 'Object', 'CerealBarChocolateBanana', 'LivingRoom', 'Other', 'Cereal', 'HighTable', 'AppleJuice', 'BarTable', 'WhiteDrawer', 'TrashBin', 'TV', 'CoffeeTable', 'Bar', 'Plate', 'Plane', 'Location', 'Toothpaste', 'Noodles', 'RedSpritzer', 'Chair', 'Corn', 'Furniture', 'Trashbag', 'Tomatoes', 'BigCoke', 'SideTable', 'KitchenStuff', 'NutFruitMix', 'OrangeJuice', 'KitchenTable', 'Wall', 'GetIt', 'Male', 'SparklingWater', 'Cabinet', 'TrashCan', 'Fork', 'Soap', 'Sauerkraut', 'Hallway', 'Bowl', 'CleaningStuff', 'FruitBarApple', 'Bed', 'Orange', 'IsoDrink', 'Pepper', 'Salt', 'BigWater', 'Tray', 'Drinks', 'Bookcase', 'Bouillon', 'Female', 'Room', 'FruitBarForestFruit', 'Cloth', 'Couch', 'Basket', 'Food', 'Desk', 'Care', 'Lemon', 'Sideboard', 'PeanutBits', 'CerealBarChocolate', 'Knife', 'SeasoningMix', 'Dishwasher', 'Cracker', 'BigLemonJuice']\n"
+      "['Sofa', 'Toothpaste', 'CoffeeTable', 'KitchenCabinet', 'KitchenStuff', 'Fork', 'Pepper', 'BigCoke', 'Coathanger', 'FruitBarForestFruit', 'Snacks', 'PeanutBits', 'SeasoningMix', 'WhiteDrawer', 'Female', 'Other', 'Kitchen', 'Desk', 'Corn', 'Couch', 'RedSpritzer', 'Knife', 'Cracker', 'LivingRoom', 'Sideboard', 'FruitBarApple', 'Male', 'Furniture', 'Spoon', 'Container', 'Cabinet', 'CleaningStuff', 'CerealBarChocolateBanana', 'Person', 'Bedroom', 'Bed', 'SparklingWater', 'Room', 'TV', 'TrashBin', 'Trashbag', 'SideTable', 'BarTable', 'Chair', 'Cup', 'Object', 'Fruit', 'Bowl', 'KitchenTable', 'DishwasherTab', 'GetIt', 'IsoDrink', 'Care', 'ShowerGel', 'Cloth', 'Location', 'Salt', 'TVTable', 'Dishwasher', 'BigLemonJuice', 'Bouillon', 'HighTable', 'Basket', 'CerealBarChocolate', 'Milk', 'BigWater', 'AppleJuice', 'Hallway', 'Lemon', 'Drinks', 'Tomatoes', 'Cereal', 'NutFruitMix', 'Plane', 'Orange', 'OrangeJuice', 'Sauerkraut', 'TrashCan', 'Food', 'Tray', 'Noodles', 'Cupboard', 'Plate', 'Soap', 'Wall', 'Bookcase', 'Bar']\n"
      ]
     }
    ],
@@ -102,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -111,7 +111,7 @@
        "['Fork', 'KitchenStuff', 'Object']"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -131,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {
     "scrolled": true
    },
@@ -139,10 +139,10 @@
     {
      "data": {
       "text/plain": [
-       "['KitchenStuff', 'Knife', 'Cup', 'Bowl', 'Plate', 'Spoon', 'Fork']"
+       "['KitchenStuff', 'Plate', 'Fork', 'Spoon', 'Cup', 'Knife', 'Bowl']"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -162,7 +162,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -181,12 +181,12 @@
        " 'Bouillon': [],\n",
        " 'Bowl': [],\n",
        " 'Cabinet': [],\n",
-       " 'Care': ['ShowerGel', 'Soap', 'Toothpaste'],\n",
+       " 'Care': ['Toothpaste', 'ShowerGel', 'Soap'],\n",
        " 'Cereal': [],\n",
        " 'CerealBarChocolate': [],\n",
        " 'CerealBarChocolateBanana': [],\n",
        " 'Chair': [],\n",
-       " 'CleaningStuff': ['Cloth', 'DishwasherTab'],\n",
+       " 'CleaningStuff': ['DishwasherTab', 'Cloth'],\n",
        " 'Cloth': [],\n",
        " 'Coathanger': [],\n",
        " 'CoffeeTable': [],\n",
@@ -199,147 +199,147 @@
        " 'Desk': [],\n",
        " 'Dishwasher': [],\n",
        " 'DishwasherTab': [],\n",
-       " 'Drinks': ['BigCoke',\n",
-       "  'Milk',\n",
-       "  'BigWater',\n",
-       "  'SparklingWater',\n",
-       "  'BigLemonJuice',\n",
-       "  'OrangeJuice',\n",
-       "  'RedSpritzer',\n",
+       " 'Drinks': ['BigLemonJuice',\n",
        "  'IsoDrink',\n",
-       "  'AppleJuice'],\n",
+       "  'RedSpritzer',\n",
+       "  'AppleJuice',\n",
+       "  'OrangeJuice',\n",
+       "  'BigCoke',\n",
+       "  'SparklingWater',\n",
+       "  'BigWater',\n",
+       "  'Milk'],\n",
        " 'Female': [],\n",
        " 'Food': ['Cereal',\n",
-       "  'Tomatoes',\n",
-       "  'Noodles',\n",
        "  'Salt',\n",
-       "  'Corn',\n",
-       "  'SeasoningMix',\n",
        "  'Pepper',\n",
+       "  'Tomatoes',\n",
+       "  'Sauerkraut',\n",
+       "  'Noodles',\n",
+       "  'Corn',\n",
        "  'Bouillon',\n",
-       "  'Sauerkraut'],\n",
+       "  'SeasoningMix'],\n",
        " 'Fork': [],\n",
        " 'Fruit': ['Lemon', 'Orange'],\n",
        " 'FruitBarApple': [],\n",
        " 'FruitBarForestFruit': [],\n",
-       " 'Furniture': ['KitchenCabinet',\n",
-       "  'CoffeeTable',\n",
-       "  'Sofa',\n",
-       "  'Cabinet',\n",
-       "  'Bookcase',\n",
-       "  'KitchenTable',\n",
-       "  'Desk',\n",
-       "  'Couch',\n",
-       "  'TrashCan',\n",
-       "  'SideTable',\n",
-       "  'Sideboard',\n",
-       "  'HighTable',\n",
-       "  'Cupboard',\n",
-       "  'Bed',\n",
-       "  'Dishwasher',\n",
-       "  'TrashBin',\n",
-       "  'TVTable',\n",
+       " 'Furniture': ['Couch',\n",
        "  'BarTable',\n",
-       "  'WhiteDrawer',\n",
+       "  'Cabinet',\n",
+       "  'HighTable',\n",
+       "  'KitchenTable',\n",
        "  'Chair',\n",
+       "  'Coathanger',\n",
+       "  'Sofa',\n",
        "  'TV',\n",
-       "  'Coathanger'],\n",
+       "  'Cupboard',\n",
+       "  'KitchenCabinet',\n",
+       "  'SideTable',\n",
+       "  'TVTable',\n",
+       "  'Dishwasher',\n",
+       "  'Bed',\n",
+       "  'Desk',\n",
+       "  'TrashCan',\n",
+       "  'Sideboard',\n",
+       "  'WhiteDrawer',\n",
+       "  'TrashBin',\n",
+       "  'CoffeeTable',\n",
+       "  'Bookcase'],\n",
        " 'GetIt': [],\n",
        " 'Hallway': [],\n",
        " 'HighTable': [],\n",
        " 'IsoDrink': [],\n",
        " 'Kitchen': [],\n",
        " 'KitchenCabinet': [],\n",
-       " 'KitchenStuff': ['Knife', 'Cup', 'Bowl', 'Plate', 'Spoon', 'Fork'],\n",
+       " 'KitchenStuff': ['Plate', 'Fork', 'Spoon', 'Cup', 'Knife', 'Bowl'],\n",
        " 'KitchenTable': [],\n",
        " 'Knife': [],\n",
        " 'Lemon': [],\n",
        " 'LivingRoom': [],\n",
        " 'Location': ['Room',\n",
-       "  'Bar',\n",
        "  'Kitchen',\n",
-       "  'Bedroom',\n",
        "  'Hallway',\n",
        "  'LivingRoom',\n",
+       "  'Bar',\n",
+       "  'Bedroom',\n",
        "  'Wall'],\n",
        " 'Male': [],\n",
        " 'Milk': [],\n",
        " 'Noodles': [],\n",
        " 'NutFruitMix': [],\n",
-       " 'Object': ['Care',\n",
-       "  'ShowerGel',\n",
-       "  'Soap',\n",
-       "  'Toothpaste',\n",
+       " 'Object': ['CleaningStuff',\n",
+       "  'DishwasherTab',\n",
+       "  'Cloth',\n",
        "  'KitchenStuff',\n",
-       "  'Knife',\n",
-       "  'Cup',\n",
-       "  'Bowl',\n",
        "  'Plate',\n",
-       "  'Spoon',\n",
        "  'Fork',\n",
-       "  'Fruit',\n",
-       "  'Lemon',\n",
-       "  'Orange',\n",
-       "  'Snacks',\n",
-       "  'FruitBarForestFruit',\n",
-       "  'FruitBarApple',\n",
-       "  'NutFruitMix',\n",
-       "  'CerealBarChocolateBanana',\n",
-       "  'Cracker',\n",
-       "  'CerealBarChocolate',\n",
-       "  'PeanutBits',\n",
-       "  'GetIt',\n",
-       "  'Furniture',\n",
-       "  'KitchenCabinet',\n",
-       "  'CoffeeTable',\n",
-       "  'Sofa',\n",
-       "  'Cabinet',\n",
-       "  'Bookcase',\n",
-       "  'KitchenTable',\n",
-       "  'Desk',\n",
-       "  'Couch',\n",
-       "  'TrashCan',\n",
-       "  'SideTable',\n",
-       "  'Sideboard',\n",
-       "  'HighTable',\n",
-       "  'Cupboard',\n",
-       "  'Bed',\n",
-       "  'Dishwasher',\n",
-       "  'TrashBin',\n",
-       "  'TVTable',\n",
-       "  'BarTable',\n",
-       "  'WhiteDrawer',\n",
-       "  'Chair',\n",
-       "  'TV',\n",
-       "  'Coathanger',\n",
-       "  'Food',\n",
-       "  'Cereal',\n",
-       "  'Tomatoes',\n",
-       "  'Noodles',\n",
-       "  'Salt',\n",
-       "  'Corn',\n",
-       "  'SeasoningMix',\n",
-       "  'Pepper',\n",
-       "  'Bouillon',\n",
-       "  'Sauerkraut',\n",
+       "  'Spoon',\n",
+       "  'Cup',\n",
+       "  'Knife',\n",
+       "  'Bowl',\n",
        "  'Container',\n",
        "  'Tray',\n",
        "  'Basket',\n",
-       "  'CleaningStuff',\n",
-       "  'Cloth',\n",
-       "  'DishwasherTab',\n",
+       "  'Food',\n",
+       "  'Cereal',\n",
+       "  'Salt',\n",
+       "  'Pepper',\n",
+       "  'Tomatoes',\n",
+       "  'Sauerkraut',\n",
+       "  'Noodles',\n",
+       "  'Corn',\n",
+       "  'Bouillon',\n",
+       "  'SeasoningMix',\n",
+       "  'Care',\n",
+       "  'Toothpaste',\n",
+       "  'ShowerGel',\n",
+       "  'Soap',\n",
+       "  'Snacks',\n",
+       "  'FruitBarForestFruit',\n",
+       "  'CerealBarChocolateBanana',\n",
+       "  'PeanutBits',\n",
+       "  'GetIt',\n",
+       "  'Cracker',\n",
+       "  'CerealBarChocolate',\n",
+       "  'NutFruitMix',\n",
+       "  'FruitBarApple',\n",
+       "  'Fruit',\n",
+       "  'Lemon',\n",
+       "  'Orange',\n",
        "  'Other',\n",
        "  'Trashbag',\n",
+       "  'Furniture',\n",
+       "  'Couch',\n",
+       "  'BarTable',\n",
+       "  'Cabinet',\n",
+       "  'HighTable',\n",
+       "  'KitchenTable',\n",
+       "  'Chair',\n",
+       "  'Coathanger',\n",
+       "  'Sofa',\n",
+       "  'TV',\n",
+       "  'Cupboard',\n",
+       "  'KitchenCabinet',\n",
+       "  'SideTable',\n",
+       "  'TVTable',\n",
+       "  'Dishwasher',\n",
+       "  'Bed',\n",
+       "  'Desk',\n",
+       "  'TrashCan',\n",
+       "  'Sideboard',\n",
+       "  'WhiteDrawer',\n",
+       "  'TrashBin',\n",
+       "  'CoffeeTable',\n",
+       "  'Bookcase',\n",
        "  'Drinks',\n",
-       "  'BigCoke',\n",
-       "  'Milk',\n",
-       "  'BigWater',\n",
-       "  'SparklingWater',\n",
        "  'BigLemonJuice',\n",
-       "  'OrangeJuice',\n",
-       "  'RedSpritzer',\n",
        "  'IsoDrink',\n",
-       "  'AppleJuice'],\n",
+       "  'RedSpritzer',\n",
+       "  'AppleJuice',\n",
+       "  'OrangeJuice',\n",
+       "  'BigCoke',\n",
+       "  'SparklingWater',\n",
+       "  'BigWater',\n",
+       "  'Milk'],\n",
        " 'Orange': [],\n",
        " 'OrangeJuice': [],\n",
        " 'Other': ['Trashbag'],\n",
@@ -349,7 +349,7 @@
        " 'Plane': [],\n",
        " 'Plate': [],\n",
        " 'RedSpritzer': [],\n",
-       " 'Room': ['Bar', 'Kitchen', 'Bedroom', 'Hallway', 'LivingRoom'],\n",
+       " 'Room': ['Kitchen', 'Hallway', 'LivingRoom', 'Bar', 'Bedroom'],\n",
        " 'Salt': [],\n",
        " 'Sauerkraut': [],\n",
        " 'SeasoningMix': [],\n",
@@ -357,13 +357,13 @@
        " 'SideTable': [],\n",
        " 'Sideboard': [],\n",
        " 'Snacks': ['FruitBarForestFruit',\n",
-       "  'FruitBarApple',\n",
-       "  'NutFruitMix',\n",
        "  'CerealBarChocolateBanana',\n",
+       "  'PeanutBits',\n",
+       "  'GetIt',\n",
        "  'Cracker',\n",
        "  'CerealBarChocolate',\n",
-       "  'PeanutBits',\n",
-       "  'GetIt'],\n",
+       "  'NutFruitMix',\n",
+       "  'FruitBarApple'],\n",
        " 'Soap': [],\n",
        " 'Sofa': [],\n",
        " 'SparklingWater': [],\n",
@@ -380,13 +380,273 @@
        " 'WhiteDrawer': []}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "ontology_interface.get_class_hierarchy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The above examples were all about retrieving information from the TBox, but we can obviously also obtain information from the ABox.\n",
+    "\n",
+    "To retrieve all instances of a given class, we can use the `get_instances_of` function, which returns a list with the names of all instances. The following examples illustrates this function by reading out all instances of class `Chair`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['BarTableChair',\n",
+       " 'HighTableChair',\n",
+       " 'KitchenTableChair2',\n",
+       " 'RightArmChair',\n",
+       " 'DeskChair',\n",
+       " 'LeftArmChair',\n",
+       " 'KitchenTableChair1']"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ontology_interface.get_instances_of('Chair')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If necessary, it is also possible to retrieve a list of all instances in the ontology regardless of their class. The `get_instances` function provides this functionality."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['KitchenEasthWall',\n",
+       " 'KitchenWestWall',\n",
+       " 'KitchenNorthWall',\n",
+       " 'KitchenCabinetTopPlaneRight1',\n",
+       " 'BedroomEasthWall',\n",
+       " 'KitchenTablePlane',\n",
+       " 'Charles',\n",
+       " 'CupboardPlane1',\n",
+       " 'RightArmChair',\n",
+       " 'HallwayWesthWall',\n",
+       " 'KitchenCabinetTopPlaneRight2',\n",
+       " 'TrashCan',\n",
+       " 'Bar',\n",
+       " 'CupboardPlane2',\n",
+       " 'Madison',\n",
+       " 'LivingRoomWesthWall',\n",
+       " 'Container',\n",
+       " 'CabinetPlane',\n",
+       " 'LivingRoomSouthhWall',\n",
+       " 'CoffeeTable',\n",
+       " 'Couch',\n",
+       " 'William',\n",
+       " 'Robert',\n",
+       " 'Cabinet',\n",
+       " 'BookcasePlane2',\n",
+       " 'BarSouthWall',\n",
+       " 'BarTable',\n",
+       " 'Dishwasher',\n",
+       " 'Sofa',\n",
+       " 'Bookcase',\n",
+       " 'Chloe',\n",
+       " 'Isabella',\n",
+       " 'Richard',\n",
+       " 'Sophia',\n",
+       " 'WhiteDrawerPlane',\n",
+       " 'John',\n",
+       " 'WhiteDrawer',\n",
+       " 'LivingRoomNorthWall',\n",
+       " 'KitchenStuff',\n",
+       " 'CoffeeTablePlane',\n",
+       " 'Bed',\n",
+       " 'David',\n",
+       " 'BedroomSouthWall',\n",
+       " 'CleaningStuff',\n",
+       " 'Emma',\n",
+       " 'BarTablePlane',\n",
+       " 'KitchenCabinetPlane',\n",
+       " 'Ava',\n",
+       " 'DeskChair',\n",
+       " 'TVTable',\n",
+       " 'Desk',\n",
+       " 'KitchenTableChair1',\n",
+       " 'BookcasePlane1',\n",
+       " 'BarWestWall',\n",
+       " 'SideTablePlane',\n",
+       " 'TrashBin',\n",
+       " 'HighTablePlane',\n",
+       " 'TV',\n",
+       " 'Drinks',\n",
+       " 'SideboardPlane',\n",
+       " 'SideTable',\n",
+       " 'LeftArmChair',\n",
+       " 'Olivia',\n",
+       " 'TVTablePlane',\n",
+       " 'Joseph',\n",
+       " 'BedroomWesthWall',\n",
+       " 'Mia',\n",
+       " 'HighTable',\n",
+       " 'Abigail',\n",
+       " 'DeskPlane',\n",
+       " 'CupboardPlane3',\n",
+       " 'BarNorthWall',\n",
+       " 'KitchenCabinet',\n",
+       " 'Thomas',\n",
+       " 'HallwayNorthWall',\n",
+       " 'BarEasthWall',\n",
+       " 'KitchenTableChair2',\n",
+       " 'LivingRoom',\n",
+       " 'LivingRoomEastWall',\n",
+       " 'Bedroom',\n",
+       " 'KitchenTable',\n",
+       " 'Michael',\n",
+       " 'DishwasherPlane',\n",
+       " 'BarTableChair',\n",
+       " 'Sideboard',\n",
+       " 'BedroomNorthWall',\n",
+       " 'KitchenCabinetTopPlaneLeft1',\n",
+       " 'Emily',\n",
+       " 'Care',\n",
+       " 'BookcasePlane3',\n",
+       " 'KitchenSouthhWall',\n",
+       " 'Hallway',\n",
+       " 'HighTableChair',\n",
+       " 'HallwayEasthWall',\n",
+       " 'James',\n",
+       " 'KitchenCabinetopPlaneLeft2',\n",
+       " 'Food',\n",
+       " 'Fruit',\n",
+       " 'Kitchen',\n",
+       " 'Snacks']"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ontology_interface.get_instances()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For locally edited ontologies, the query interface also provides functions for inserting and deleting class assertions: `insert_class_assertion` and `remove_class_assertion` respectively.\n",
+    "\n",
+    "For instance, we can insert `CornFlakes` as an instance of the `Cereal` class as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ontology_interface.insert_class_assertion('Cereal', 'CornFlakes')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['CornFlakes']"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ontology_interface.get_instances_of('Cereal')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Similarly, we can remove `CornFlakes` as an instance of the `Cereal` class as"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ontology_interface.remove_class_assertion('Cereal', 'CornFlakes')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ontology_interface.get_instances_of('Cereal')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The changes done by the `insert_class_assertion` and `remove_class_assertion` are only applied to the loaded knowledge graph, but are not saved. To actually save them to the ontology file, a call to the `update` function is necessary:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ontology_interface.update()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that we are not going to call `update` in this example since we are loading the ontology from a non-editable file from a web URL."
    ]
   },
   {
@@ -405,7 +665,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 14,
    "metadata": {
     "scrolled": true
    },
@@ -414,7 +674,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "['defaultLocation', 'locatedAt', 'toTheRightOf', 'oppositeTo', 'below', 'closeToWall', 'nextTo', 'canPlaceOn', 'hasDoor', 'above', 'connectedTo', 'closeTo', 'toTheLeftOf', 'inside', 'onTopOf']\n"
+      "['nextTo', 'hasDoor', 'toTheLeftOf', 'toTheRightOf', 'inside', 'connectedTo', 'closeTo', 'above', 'locatedAt', 'defaultLocation', 'below', 'oppositeTo', 'onTopOf', 'canPlaceOn', 'closeToWall']\n"
      ]
     }
    ],
@@ -432,7 +692,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 15,
    "metadata": {
     "scrolled": true
    },
@@ -441,21 +701,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "defaultLocation: Object -> Furniture\n",
-      "locatedAt: Object -> Location\n",
-      "toTheRightOf: Object -> Object\n",
-      "oppositeTo: Object -> Object\n",
-      "below: Object -> Object\n",
-      "closeToWall: Object -> Wall\n",
       "nextTo: Object -> Object\n",
-      "canPlaceOn: Object -> Plane\n",
       "hasDoor: Furniture -> boolean\n",
-      "above: Object -> Object\n",
+      "toTheLeftOf: Object -> Object\n",
+      "toTheRightOf: Object -> Object\n",
+      "inside: Object -> Object\n",
       "connectedTo: Room -> Room\n",
       "closeTo: Object -> Object\n",
-      "toTheLeftOf: Object -> Object\n",
-      "inside: Object -> Object\n",
-      "onTopOf: Object -> Object\n"
+      "above: Object -> Object\n",
+      "locatedAt: Object -> Location\n",
+      "defaultLocation: Object -> Furniture\n",
+      "below: Object -> Object\n",
+      "oppositeTo: Object -> Object\n",
+      "onTopOf: Object -> Object\n",
+      "canPlaceOn: Object -> Plane\n",
+      "closeToWall: Object -> Wall\n"
      ]
     }
    ],
@@ -476,7 +736,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 16,
    "metadata": {
     "scrolled": false
    },
@@ -484,31 +744,31 @@
     {
      "data": {
       "text/plain": [
-       "[('Couch', 'LivingRoom'),\n",
-       " ('Desk', 'Bedroom'),\n",
-       " ('CoffeeTable', 'LivingRoom'),\n",
-       " ('Bookcase', 'LivingRoom'),\n",
-       " ('LeftArmChair', 'LivingRoom'),\n",
-       " ('Dishwasher', 'Kitchen'),\n",
-       " ('Cabinet', 'Kitchen'),\n",
-       " ('Sofa', 'Bar'),\n",
-       " ('RightArmChair', 'LivingRoom'),\n",
-       " ('SideTable', 'Bedroom'),\n",
-       " ('Bed', 'Bedroom'),\n",
-       " ('Sideboard', 'LivingRoom'),\n",
+       "[('HighTable', 'LivingRoom'),\n",
        " ('WhiteDrawer', 'Kitchen'),\n",
-       " ('KitchenTable', 'Kitchen'),\n",
-       " ('CupBoard', 'Bar'),\n",
-       " ('BarTable', 'Bar'),\n",
-       " ('HighTable', 'LivingRoom'),\n",
+       " ('Sofa', 'Bar'),\n",
        " ('KitchenCabinet', 'Kitchen'),\n",
-       " ('TrashCan', 'Kitchen'),\n",
+       " ('SideTable', 'Bedroom'),\n",
+       " ('BarTable', 'Bar'),\n",
+       " ('Bed', 'Bedroom'),\n",
+       " ('Bookcase', 'LivingRoom'),\n",
+       " ('CoffeeTable', 'LivingRoom'),\n",
+       " ('RightArmChair', 'LivingRoom'),\n",
+       " ('LeftArmChair', 'LivingRoom'),\n",
        " ('CoatHanger', 'LivingRoom'),\n",
+       " ('Desk', 'Bedroom'),\n",
+       " ('CupBoard', 'Bar'),\n",
        " ('TrashBin', 'LivingRoom'),\n",
-       " ('TVTable', 'LivingRoom')]"
+       " ('KitchenTable', 'Kitchen'),\n",
+       " ('TrashCan', 'Kitchen'),\n",
+       " ('Sideboard', 'LivingRoom'),\n",
+       " ('Dishwasher', 'Kitchen'),\n",
+       " ('Couch', 'LivingRoom'),\n",
+       " ('TVTable', 'LivingRoom'),\n",
+       " ('Cabinet', 'Kitchen')]"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/examples/ontology_interface.ipynb
+++ b/examples/ontology_interface.ipynb
@@ -1,0 +1,542 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Ontology Query Interface Usage Examples"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The query interface is part of the `mas_knowledge_utils` package and we can import it as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mas_knowledge_utils.ontology_query_interface import OntologyQueryInterface"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Initialising an Instance of the Ontology Interface"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Instances of the query interface expect two arguments to be passed:\n",
+    "* `ontology_url`: URL at which the ontology is exposed (if the ontology is read from a local file, the path should be prefixed by `file://`)\n",
+    "* `ontology_class_prefix`: we assume that classes are defined in a namespace, so the TBox will contain declarations of the type `prefix:Class` or `prefix:ObjectProperty`\n",
+    "\n",
+    "For all examples here, we will use an ontology that was created during RoboCup German Open 2019. We host this ontology on GitHub, such that the `apartment` namespace is used for defining the ontology entities."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ontology_url = 'https://raw.githubusercontent.com/b-it-bots/mas_knowledge_base/master/common/ontology/apartment_go_2019.owl'\n",
+    "ontology_class_prefix = 'apartment'\n",
+    "ontology_interface = OntologyQueryInterface(ontology_url, ontology_class_prefix)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Reading Out Class Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The interface allows retrieving various aspects from the TBox. For instance, we can retrieve all classes in the ontology using the `get_classes` function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Sofa', 'Bedroom', 'Person', 'Milk', 'Container', 'Snacks', 'Spoon', 'Kitchen', 'KitchenCabinet', 'Cup', 'Cupboard', 'ShowerGel', 'Fruit', 'Coathanger', 'TVTable', 'DishwasherTab', 'Object', 'CerealBarChocolateBanana', 'LivingRoom', 'Other', 'Cereal', 'HighTable', 'AppleJuice', 'BarTable', 'WhiteDrawer', 'TrashBin', 'TV', 'CoffeeTable', 'Bar', 'Plate', 'Plane', 'Location', 'Toothpaste', 'Noodles', 'RedSpritzer', 'Chair', 'Corn', 'Furniture', 'Trashbag', 'Tomatoes', 'BigCoke', 'SideTable', 'KitchenStuff', 'NutFruitMix', 'OrangeJuice', 'KitchenTable', 'Wall', 'GetIt', 'Male', 'SparklingWater', 'Cabinet', 'TrashCan', 'Fork', 'Soap', 'Sauerkraut', 'Hallway', 'Bowl', 'CleaningStuff', 'FruitBarApple', 'Bed', 'Orange', 'IsoDrink', 'Pepper', 'Salt', 'BigWater', 'Tray', 'Drinks', 'Bookcase', 'Bouillon', 'Female', 'Room', 'FruitBarForestFruit', 'Cloth', 'Couch', 'Basket', 'Food', 'Desk', 'Care', 'Lemon', 'Sideboard', 'PeanutBits', 'CerealBarChocolate', 'Knife', 'SeasoningMix', 'Dishwasher', 'Cracker', 'BigLemonJuice']\n"
+     ]
+    }
+   ],
+   "source": [
+    "classes = ontology_interface.get_classes()\n",
+    "print(classes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This ontology is rather small, so the number of classes is rather manageable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition to retrieving all classes, we can also retrieve a list of all parent classes of a given class:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['Fork', 'KitchenStuff', 'Object']"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ontology_interface.get_parent_classes_of('Fork')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It should be noted that a class is a parent of itself, so the query class is also included in the result.\n",
+    "\n",
+    "In some cases, we may also be interested in retrieving all subclasses of a given class:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['KitchenStuff', 'Knife', 'Cup', 'Bowl', 'Plate', 'Spoon', 'Fork']"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ontology_interface.get_subclasses_of('KitchenStuff')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As above, a class is a subclass of itself.\n",
+    "\n",
+    "The above functions implicitly allow us to extract the hierarchy of classes in the ontology. The interface also allows us to get the hierarchy explicitly in the form of a dictionary in which each key is a class name and the corresponding value is a list of subclasses of the class. This is done through the `get_class_hierarchy` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'AppleJuice': [],\n",
+       " 'Bar': [],\n",
+       " 'BarTable': [],\n",
+       " 'Basket': [],\n",
+       " 'Bed': [],\n",
+       " 'Bedroom': [],\n",
+       " 'BigCoke': [],\n",
+       " 'BigLemonJuice': [],\n",
+       " 'BigWater': [],\n",
+       " 'Bookcase': [],\n",
+       " 'Bouillon': [],\n",
+       " 'Bowl': [],\n",
+       " 'Cabinet': [],\n",
+       " 'Care': ['ShowerGel', 'Soap', 'Toothpaste'],\n",
+       " 'Cereal': [],\n",
+       " 'CerealBarChocolate': [],\n",
+       " 'CerealBarChocolateBanana': [],\n",
+       " 'Chair': [],\n",
+       " 'CleaningStuff': ['Cloth', 'DishwasherTab'],\n",
+       " 'Cloth': [],\n",
+       " 'Coathanger': [],\n",
+       " 'CoffeeTable': [],\n",
+       " 'Container': ['Tray', 'Basket'],\n",
+       " 'Corn': [],\n",
+       " 'Couch': [],\n",
+       " 'Cracker': [],\n",
+       " 'Cup': [],\n",
+       " 'Cupboard': [],\n",
+       " 'Desk': [],\n",
+       " 'Dishwasher': [],\n",
+       " 'DishwasherTab': [],\n",
+       " 'Drinks': ['BigCoke',\n",
+       "  'Milk',\n",
+       "  'BigWater',\n",
+       "  'SparklingWater',\n",
+       "  'BigLemonJuice',\n",
+       "  'OrangeJuice',\n",
+       "  'RedSpritzer',\n",
+       "  'IsoDrink',\n",
+       "  'AppleJuice'],\n",
+       " 'Female': [],\n",
+       " 'Food': ['Cereal',\n",
+       "  'Tomatoes',\n",
+       "  'Noodles',\n",
+       "  'Salt',\n",
+       "  'Corn',\n",
+       "  'SeasoningMix',\n",
+       "  'Pepper',\n",
+       "  'Bouillon',\n",
+       "  'Sauerkraut'],\n",
+       " 'Fork': [],\n",
+       " 'Fruit': ['Lemon', 'Orange'],\n",
+       " 'FruitBarApple': [],\n",
+       " 'FruitBarForestFruit': [],\n",
+       " 'Furniture': ['KitchenCabinet',\n",
+       "  'CoffeeTable',\n",
+       "  'Sofa',\n",
+       "  'Cabinet',\n",
+       "  'Bookcase',\n",
+       "  'KitchenTable',\n",
+       "  'Desk',\n",
+       "  'Couch',\n",
+       "  'TrashCan',\n",
+       "  'SideTable',\n",
+       "  'Sideboard',\n",
+       "  'HighTable',\n",
+       "  'Cupboard',\n",
+       "  'Bed',\n",
+       "  'Dishwasher',\n",
+       "  'TrashBin',\n",
+       "  'TVTable',\n",
+       "  'BarTable',\n",
+       "  'WhiteDrawer',\n",
+       "  'Chair',\n",
+       "  'TV',\n",
+       "  'Coathanger'],\n",
+       " 'GetIt': [],\n",
+       " 'Hallway': [],\n",
+       " 'HighTable': [],\n",
+       " 'IsoDrink': [],\n",
+       " 'Kitchen': [],\n",
+       " 'KitchenCabinet': [],\n",
+       " 'KitchenStuff': ['Knife', 'Cup', 'Bowl', 'Plate', 'Spoon', 'Fork'],\n",
+       " 'KitchenTable': [],\n",
+       " 'Knife': [],\n",
+       " 'Lemon': [],\n",
+       " 'LivingRoom': [],\n",
+       " 'Location': ['Room',\n",
+       "  'Bar',\n",
+       "  'Kitchen',\n",
+       "  'Bedroom',\n",
+       "  'Hallway',\n",
+       "  'LivingRoom',\n",
+       "  'Wall'],\n",
+       " 'Male': [],\n",
+       " 'Milk': [],\n",
+       " 'Noodles': [],\n",
+       " 'NutFruitMix': [],\n",
+       " 'Object': ['Care',\n",
+       "  'ShowerGel',\n",
+       "  'Soap',\n",
+       "  'Toothpaste',\n",
+       "  'KitchenStuff',\n",
+       "  'Knife',\n",
+       "  'Cup',\n",
+       "  'Bowl',\n",
+       "  'Plate',\n",
+       "  'Spoon',\n",
+       "  'Fork',\n",
+       "  'Fruit',\n",
+       "  'Lemon',\n",
+       "  'Orange',\n",
+       "  'Snacks',\n",
+       "  'FruitBarForestFruit',\n",
+       "  'FruitBarApple',\n",
+       "  'NutFruitMix',\n",
+       "  'CerealBarChocolateBanana',\n",
+       "  'Cracker',\n",
+       "  'CerealBarChocolate',\n",
+       "  'PeanutBits',\n",
+       "  'GetIt',\n",
+       "  'Furniture',\n",
+       "  'KitchenCabinet',\n",
+       "  'CoffeeTable',\n",
+       "  'Sofa',\n",
+       "  'Cabinet',\n",
+       "  'Bookcase',\n",
+       "  'KitchenTable',\n",
+       "  'Desk',\n",
+       "  'Couch',\n",
+       "  'TrashCan',\n",
+       "  'SideTable',\n",
+       "  'Sideboard',\n",
+       "  'HighTable',\n",
+       "  'Cupboard',\n",
+       "  'Bed',\n",
+       "  'Dishwasher',\n",
+       "  'TrashBin',\n",
+       "  'TVTable',\n",
+       "  'BarTable',\n",
+       "  'WhiteDrawer',\n",
+       "  'Chair',\n",
+       "  'TV',\n",
+       "  'Coathanger',\n",
+       "  'Food',\n",
+       "  'Cereal',\n",
+       "  'Tomatoes',\n",
+       "  'Noodles',\n",
+       "  'Salt',\n",
+       "  'Corn',\n",
+       "  'SeasoningMix',\n",
+       "  'Pepper',\n",
+       "  'Bouillon',\n",
+       "  'Sauerkraut',\n",
+       "  'Container',\n",
+       "  'Tray',\n",
+       "  'Basket',\n",
+       "  'CleaningStuff',\n",
+       "  'Cloth',\n",
+       "  'DishwasherTab',\n",
+       "  'Other',\n",
+       "  'Trashbag',\n",
+       "  'Drinks',\n",
+       "  'BigCoke',\n",
+       "  'Milk',\n",
+       "  'BigWater',\n",
+       "  'SparklingWater',\n",
+       "  'BigLemonJuice',\n",
+       "  'OrangeJuice',\n",
+       "  'RedSpritzer',\n",
+       "  'IsoDrink',\n",
+       "  'AppleJuice'],\n",
+       " 'Orange': [],\n",
+       " 'OrangeJuice': [],\n",
+       " 'Other': ['Trashbag'],\n",
+       " 'PeanutBits': [],\n",
+       " 'Pepper': [],\n",
+       " 'Person': ['Female', 'Male'],\n",
+       " 'Plane': [],\n",
+       " 'Plate': [],\n",
+       " 'RedSpritzer': [],\n",
+       " 'Room': ['Bar', 'Kitchen', 'Bedroom', 'Hallway', 'LivingRoom'],\n",
+       " 'Salt': [],\n",
+       " 'Sauerkraut': [],\n",
+       " 'SeasoningMix': [],\n",
+       " 'ShowerGel': [],\n",
+       " 'SideTable': [],\n",
+       " 'Sideboard': [],\n",
+       " 'Snacks': ['FruitBarForestFruit',\n",
+       "  'FruitBarApple',\n",
+       "  'NutFruitMix',\n",
+       "  'CerealBarChocolateBanana',\n",
+       "  'Cracker',\n",
+       "  'CerealBarChocolate',\n",
+       "  'PeanutBits',\n",
+       "  'GetIt'],\n",
+       " 'Soap': [],\n",
+       " 'Sofa': [],\n",
+       " 'SparklingWater': [],\n",
+       " 'Spoon': [],\n",
+       " 'TV': [],\n",
+       " 'TVTable': [],\n",
+       " 'Tomatoes': [],\n",
+       " 'Toothpaste': [],\n",
+       " 'TrashBin': [],\n",
+       " 'TrashCan': [],\n",
+       " 'Trashbag': [],\n",
+       " 'Tray': [],\n",
+       " 'Wall': [],\n",
+       " 'WhiteDrawer': []}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ontology_interface.get_class_hierarchy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Retrieving Object Property Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Just as we can obtain a list of all classes, we can also obtain a list of all object properties in the ontology. We can do this using the `get_object_properties` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['defaultLocation', 'locatedAt', 'toTheRightOf', 'oppositeTo', 'below', 'closeToWall', 'nextTo', 'canPlaceOn', 'hasDoor', 'above', 'connectedTo', 'closeTo', 'toTheLeftOf', 'inside', 'onTopOf']\n"
+     ]
+    }
+   ],
+   "source": [
+    "object_properties = ontology_interface.get_object_properties()\n",
+    "print(object_properties)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In some cases, obtaining the type of a property is also useful. The following snippet uses the `get_property_domain_range` function to obtain the domain and range of all properties in the ontology."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "defaultLocation: Object -> Furniture\n",
+      "locatedAt: Object -> Location\n",
+      "toTheRightOf: Object -> Object\n",
+      "oppositeTo: Object -> Object\n",
+      "below: Object -> Object\n",
+      "closeToWall: Object -> Wall\n",
+      "nextTo: Object -> Object\n",
+      "canPlaceOn: Object -> Plane\n",
+      "hasDoor: Furniture -> boolean\n",
+      "above: Object -> Object\n",
+      "connectedTo: Room -> Room\n",
+      "closeTo: Object -> Object\n",
+      "toTheLeftOf: Object -> Object\n",
+      "inside: Object -> Object\n",
+      "onTopOf: Object -> Object\n"
+     ]
+    }
+   ],
+   "source": [
+    "for prop in object_properties:\n",
+    "    (prop_domain, prop_range) = ontology_interface.get_property_domain_range(prop)\n",
+    "    print('{0}: {1} -> {2}'.format(prop, prop_domain, prop_range))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Given a property, we can also retrieve all of its assertions using the `get_all_subjects_and_objects` function. This function returns a list of pairs in which the first element is the subject and the second element is the object.\n",
+    "\n",
+    "The following example returns the locations of various furniture items in the apartment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('Couch', 'LivingRoom'),\n",
+       " ('Desk', 'Bedroom'),\n",
+       " ('CoffeeTable', 'LivingRoom'),\n",
+       " ('Bookcase', 'LivingRoom'),\n",
+       " ('LeftArmChair', 'LivingRoom'),\n",
+       " ('Dishwasher', 'Kitchen'),\n",
+       " ('Cabinet', 'Kitchen'),\n",
+       " ('Sofa', 'Bar'),\n",
+       " ('RightArmChair', 'LivingRoom'),\n",
+       " ('SideTable', 'Bedroom'),\n",
+       " ('Bed', 'Bedroom'),\n",
+       " ('Sideboard', 'LivingRoom'),\n",
+       " ('WhiteDrawer', 'Kitchen'),\n",
+       " ('KitchenTable', 'Kitchen'),\n",
+       " ('CupBoard', 'Bar'),\n",
+       " ('BarTable', 'Bar'),\n",
+       " ('HighTable', 'LivingRoom'),\n",
+       " ('KitchenCabinet', 'Kitchen'),\n",
+       " ('TrashCan', 'Kitchen'),\n",
+       " ('CoatHanger', 'LivingRoom'),\n",
+       " ('TrashBin', 'LivingRoom'),\n",
+       " ('TVTable', 'LivingRoom')]"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ontology_interface.get_all_subjects_and_objects('locatedAt')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Addressed https://github.com/b-it-bots/mas_knowledge_base/issues/24

The PR adds a directory `examples`, which currently includes a Jupyter notebook `ontology_interface.ipynb`, which illustrates how various functions of the ontology interface are used.