### PR TITLE
[Feature] Add unit-tests for validating the OntologyQueryInterface APIs with ontologies that do not have a namespace

### DIFF
--- a/common/mas_knowledge_utils/ontology_query_interface.py
+++ b/common/mas_knowledge_utils/ontology_query_interface.py
@@ -135,7 +135,7 @@ class OntologyQueryInterface(object):
 
         '''
         if self.is_class(class_name):
-            rdf_class = self.__format_class_name(class_name)
+            rdf_class = self.__format_class_name(class_name, as_sparql_url=True)
             query_result = self.knowledge_graph.query('SELECT ?instance ' +
                                                       'WHERE {?instance rdf:type ' + rdf_class + '}')
             instances = [self.__extract_obj_name(x[0]) for x in query_result]
@@ -194,7 +194,7 @@ class OntologyQueryInterface(object):
             raise ValueError('"{0}" does not exist as an instance in the ontology!'.format(obj))
         else:
             object_url = self.__get_entity_url(obj)
-            rdf_property = self.__format_class_name(prop)
+            rdf_property = self.__format_class_name(prop, as_sparql_url=True)
             query_result = self.knowledge_graph.query('SELECT ?subj ' +
                                                       'WHERE {?subj ' + rdf_property +
                                                       ' <' + object_url +  '>}')
@@ -218,7 +218,7 @@ class OntologyQueryInterface(object):
             raise ValueError('"{0}" does not exist as an instance in the ontology!'.format(subject))
         else:
             subject_url = self.__get_entity_url(subject)
-            rdf_property = self.__format_class_name(prop)
+            rdf_property = self.__format_class_name(prop, as_sparql_url=True)
             query_result = self.knowledge_graph.query('SELECT ?obj ' +
                                                       'WHERE {<' + subject_url + '> ' +
                                                       rdf_property + ' ?obj}')
@@ -235,7 +235,7 @@ class OntologyQueryInterface(object):
 
         '''
         if self.is_property(prop):
-            rdf_property = self.__format_class_name(prop)
+            rdf_property = self.__format_class_name(prop, as_sparql_url=True)
             query_result = self.knowledge_graph.query('SELECT ?subj ?obj ' +
                                                       'WHERE {?subj ' + rdf_property + ' ?obj}')
             subj_obj_pairs = [(self.__extract_obj_name(x[0]),
@@ -373,7 +373,7 @@ class OntologyQueryInterface(object):
         '''
         self.export(self.ontology_file, format=format)
 
-    def __format_class_name(self, class_name):
+    def __format_class_name(self, class_name, as_sparql_url=False):
         '''Returns a string of the format "self.class_prefix:class_name",
         or "class_name" if self.class_prefix is empty.
 
@@ -383,7 +383,10 @@ class OntologyQueryInterface(object):
         '''
         if self.class_prefix:
             return '{0}:{1}'.format(self.class_prefix, class_name)
-        return class_name
+        elif as_sparql_url:
+            return '<' + self.__get_entity_url(class_name) + '>'
+        else:
+            return self.__get_entity_url(class_name)
 
     def __get_entity_url(self, entity):
         '''Returns a string of the format "self.ontology_url/entity"
@@ -405,7 +408,7 @@ class OntologyQueryInterface(object):
         '''
         if self.class_prefix:
             return rdf_class[rdf_class.find(':')+1:]
-        return rdf_class
+        return self.__extract_obj_name(rdf_class)
 
     def __extract_obj_name(self, obj_url):
         '''Extracts the name of an object from the given full URL,

--- a/common/mas_knowledge_utils/ontology_query_interface.py
+++ b/common/mas_knowledge_utils/ontology_query_interface.py
@@ -281,10 +281,9 @@ class OntologyQueryInterface(object):
 
         '''
         if self.is_class(class_name):
-            ns = rdflib.Namespace("http://{0}#".format(self.class_prefix))
             self.knowledge_graph.add((rdflib.URIRef(self.__get_entity_url(instance_name)),
                                       rdflib.RDF.type,
-                                      rdflib.URIRef(ns[class_name])))
+                                      self.__get_entity_uriref(class_name)))
             # Reset instance names list to ensure that the newly added
             # instance is included in the next query to the instance_list
             self.__instance_names = None
@@ -308,9 +307,8 @@ class OntologyQueryInterface(object):
         elif not self.is_property(property_name):
             raise ValueError('The property "{0}" is not defined in the ontology!'.format(property_name))
         else:
-            ns = rdflib.Namespace("http://{0}#".format(self.class_prefix))
             self.knowledge_graph.add((rdflib.URIRef(self.__get_entity_url(instance[0])),
-                                      rdflib.URIRef(ns[property_name]),
+                                      self.__get_entity_uriref(property_name),
                                       rdflib.URIRef(self.__get_entity_url(instance[1]))))
 
     def remove_class_assertion(self, class_name, instance_name):
@@ -328,10 +326,9 @@ class OntologyQueryInterface(object):
         elif not self.is_instance_of(instance_name, class_name):
             raise ValueError('"{0}" is not an instance of {1}!'.format(instance_name, class_name))
         else:
-            ns = rdflib.Namespace("http://{0}#".format(self.class_prefix))
             self.knowledge_graph.remove((rdflib.URIRef(self.__get_entity_url(instance_name)),
                                       rdflib.RDF.type,
-                                      rdflib.URIRef(ns[class_name])))
+                                      self.__get_entity_uriref(class_name)))
             # Reset instance names list to ensure that the removed instance is
             # not included in the next query to the instance_list
             self.__instance_names = None
@@ -353,9 +350,8 @@ class OntologyQueryInterface(object):
         elif not self.is_property(property_name):
             raise ValueError('The property "{0}" is not defined in the ontology!'.format(property_name))
         else:
-            ns = rdflib.Namespace("http://{0}#".format(self.class_prefix))
             self.knowledge_graph.remove((rdflib.URIRef(self.__get_entity_url(instance[0])),
-                                      rdflib.URIRef(ns[property_name]),
+                                      self.__get_entity_uriref(property_name),
                                       rdflib.URIRef(self.__get_entity_url(instance[1]))))
 
     def export(self, ontology_file, format='xml'):
@@ -396,6 +392,19 @@ class OntologyQueryInterface(object):
 
         '''
         return '{0}/{1}'.format(self.ontology_url, entity)
+
+    def __get_entity_uriref(self, entity):
+        '''Returns a rdflib.URIRef object for the entity.
+
+        Keyword arguments:
+        @param entity -- string representing the name of an entity in the ontology
+
+        '''
+        if self.class_prefix:
+            ns = rdflib.Namespace("http://{0}#".format(self.class_prefix))
+            return rdflib.URIRef(ns[entity])
+        else:
+            return rdflib.URIRef(self.__get_entity_url(entity))
 
     def __extract_class_name(self, rdf_class):
         '''Extracts the name of a class given a string

--- a/common/mas_knowledge_utils/ontology_query_interface.py
+++ b/common/mas_knowledge_utils/ontology_query_interface.py
@@ -135,7 +135,7 @@ class OntologyQueryInterface(object):
 
         '''
         if self.is_class(class_name):
-            rdf_class = self.__format_class_name(class_name, as_sparql_url=True)
+            rdf_class = self.__format_class_name(class_name, sparql_url_hint=True)
             query_result = self.knowledge_graph.query('SELECT ?instance ' +
                                                       'WHERE {?instance rdf:type ' + rdf_class + '}')
             instances = [self.__extract_obj_name(x[0]) for x in query_result]
@@ -194,7 +194,7 @@ class OntologyQueryInterface(object):
             raise ValueError('"{0}" does not exist as an instance in the ontology!'.format(obj))
         else:
             object_url = self.__get_entity_url(obj)
-            rdf_property = self.__format_class_name(prop, as_sparql_url=True)
+            rdf_property = self.__format_class_name(prop, sparql_url_hint=True)
             query_result = self.knowledge_graph.query('SELECT ?subj ' +
                                                       'WHERE {?subj ' + rdf_property +
                                                       ' <' + object_url +  '>}')
@@ -218,7 +218,7 @@ class OntologyQueryInterface(object):
             raise ValueError('"{0}" does not exist as an instance in the ontology!'.format(subject))
         else:
             subject_url = self.__get_entity_url(subject)
-            rdf_property = self.__format_class_name(prop, as_sparql_url=True)
+            rdf_property = self.__format_class_name(prop, sparql_url_hint=True)
             query_result = self.knowledge_graph.query('SELECT ?obj ' +
                                                       'WHERE {<' + subject_url + '> ' +
                                                       rdf_property + ' ?obj}')
@@ -235,7 +235,7 @@ class OntologyQueryInterface(object):
 
         '''
         if self.is_property(prop):
-            rdf_property = self.__format_class_name(prop, as_sparql_url=True)
+            rdf_property = self.__format_class_name(prop, sparql_url_hint=True)
             query_result = self.knowledge_graph.query('SELECT ?subj ?obj ' +
                                                       'WHERE {?subj ' + rdf_property + ' ?obj}')
             subj_obj_pairs = [(self.__extract_obj_name(x[0]),
@@ -369,17 +369,21 @@ class OntologyQueryInterface(object):
         '''
         self.export(self.ontology_file, format=format)
 
-    def __format_class_name(self, class_name, as_sparql_url=False):
+    def __format_class_name(self, class_name, sparql_url_hint=False):
         '''Returns a string of the format "self.class_prefix:class_name",
         or "class_name" if self.class_prefix is empty.
 
         Keyword arguments:
         @param class_name -- string representing the name of a class
+        @param sparql_url_hint -- boolean representing if the class name url
+                                  should be returned as <url> to support
+                                  SPARQL queries. This flag only takes effect if
+                                  the class_prefix is not defined.
 
         '''
         if self.class_prefix:
             return '{0}:{1}'.format(self.class_prefix, class_name)
-        elif as_sparql_url:
+        elif sparql_url_hint:
             return '<' + self.__get_entity_url(class_name) + '>'
         else:
             return self.__get_entity_url(class_name)
@@ -409,7 +413,8 @@ class OntologyQueryInterface(object):
     def __extract_class_name(self, rdf_class):
         '''Extracts the name of a class given a string
         of the format "self.class_prefix:class_name".
-        Returns "rdf_class" if self.class_prefix is empty.
+        If the class_prefix is undefined, the API assumes the rdf_class is a URL
+        and returns the last element in the URL as the class name
 
         Keyword arguments:
         @param rdf_class -- string of the form "prefix:class"

--- a/common/ontology/sample_no_class_prefix.owl
+++ b/common/ontology/sample_no_class_prefix.owl
@@ -1,0 +1,104 @@
+<!DOCTYPE rdf:RDF [
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#">
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
+]>
+
+<rdf:RDF
+    xmlns:apartment="http://apartment#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+
+    <owl:Ontology rdf:about="http://apartment" />
+
+    <!--************* Class definitions ************-->
+    <owl:Class rdf:about="Object"/>
+    <owl:Class rdf:about="Location"/>
+
+    <!-- Location items -->
+    <owl:Class rdf:about="Room"/>
+
+    <!-- Furniture items -->
+    <owl:Class rdf:about="Furniture"/>
+    <owl:Class rdf:about="Table"/>
+    <owl:Class rdf:about="WorkTable"/>
+
+    <!-- Drinkware -->
+    <owl:Class rdf:about="Drinkware"/>
+    <owl:Class rdf:about="Mug"/>
+    <!--*********************************************-->
+
+    <!--*********** Subclass definitions ************-->
+
+    <!-- Location subclass definitions -->
+    <owl:Class rdf:about="Room">
+        <rdfs:subClassOf rdf:resource="Location"/>
+    </owl:Class>
+
+    <!-- Object subclass definitions -->
+    <owl:Class rdf:about="Furniture">
+        <rdfs:subClassOf rdf:resource="Object"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="Table">
+        <rdfs:subClassOf rdf:resource="Furniture"/>
+    </owl:Class>
+    <owl:Class rdf:about="WorkTable">
+        <rdfs:subClassOf rdf:resource="Table"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="Drinkware">
+        <rdfs:subClassOf rdf:resource="Object"/>
+    </owl:Class>
+    <owl:Class rdf:about="Mug">
+        <rdfs:subClassOf rdf:resource="Drinkware"/>
+    </owl:Class>
+    <!--*********************************************-->
+
+
+    <!--************ Property definitions ***********-->
+
+    <owl:ObjectProperty rdf:about="locatedAt">
+        <rdf:type rdf:resource="&owl;FunctionalProperty" />
+        <rdfs:domain rdf:resource="Object"/>
+        <rdfs:range rdf:resource="Room"/>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="defaultStoringLocation">
+        <rdf:type rdf:resource="&owl;FunctionalProperty" />
+        <rdfs:domain rdf:resource="Object"/>
+        <rdfs:range rdf:resource="Furniture"/>
+    </owl:ObjectProperty>
+
+    <owl:ObjectProperty rdf:about="heightOf">
+        <rdfs:domain rdf:resource="Object"/>
+        <rdfs:range rdf:resource="xsd:float"/>
+    </owl:ObjectProperty>
+    <!--*********************************************-->
+
+
+    <!--************** Class Instances **************-->
+
+    <Room rdf:about="HomeOffice"/>
+    <WorkTable rdf:about="Desk"/>
+    <Mug rdf:about="CoffeeMug"/>
+    <!--*********************************************-->
+
+
+    <!--************** Property Assertions **************-->
+
+    <rdf:Description rdf:about="Desk">
+        <locatedAt rdf:resource="HomeOffice"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="CoffeeMug">
+        <defaultStoringLocation rdf:resource="Desk"/>
+    </rdf:Description>
+    <rdf:Description rdf:about="Desk">
+        <heightOf rdf:resource="0.7"/>
+    </rdf:Description>
+    <!--*********************************************-->
+
+
+</rdf:RDF>

--- a/common/ontology/sample_no_namespace.owl
+++ b/common/ontology/sample_no_namespace.owl
@@ -11,8 +11,6 @@
     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 
-    <owl:Ontology rdf:about="http://apartment" />
-
     <!--************* Class definitions ************-->
     <owl:Class rdf:about="Object"/>
     <owl:Class rdf:about="Location"/>

--- a/common/tests/ontology_query_interface_unit_tests.py
+++ b/common/tests/ontology_query_interface_unit_tests.py
@@ -182,5 +182,28 @@ class ontology_query_interface_test(unittest.TestCase):
         self.assertEqual(self.ont_if.get_objects_of("locatedAt", "Desk"), [])
         self.assertEqual(self.ont_if.get_objects_of("heightOf", "Desk"), [])
 
+class ontology_query_interface_test_no_class_prefix(ontology_query_interface_test):
+    '''Implements unit tests for the OntologyQueryInterface APIs
+    using an ontology that has no namespace (or class_prefix)
+
+    @author Sushant Chavan
+    @contact sushant.chavan@smail.inf.h-brs.de
+
+    '''
+
+    def setUp(self):
+        # Get directory paths
+        script_dir = os.path.abspath(os.path.dirname(__file__))
+        ontology_dir = os.path.join(os.path.dirname(script_dir), "ontology")
+
+        # Get the filepath for the ontology
+        self.ontology_file_path = "file://" + os.path.join(ontology_dir, "sample_no_namespace.owl")
+        # This ontology does not have a namespace, hence None
+        self.ontology_ns = None
+
+        # Create an instance of the ontology interface
+        self.ont_if = OntologyQueryInterface(ontology_file=self.ontology_file_path,
+                                             class_prefix=self.ontology_ns)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds a new test class that re-tests all the APIs of the OntologyQueryInterface but with an ontology that does not have a namespace.

## Changelog
<!-- Add a list of bullets with the summary of your changes -->
<!-- Try to use infinitives: Fix, Remove, Rename, Add, Refactor -->

* Added a modified version of the sample ontology, where the classes and properties are defined without a namespace
* Updated the class name extraction and generation APIs to support the above ontology
* Added a new API to construct the URIRef for a given entity name which is needed in the TBox insertion APIs
* Added a new sub-class of the previous Unit test class to support testing the APIs with ontologies without a namespace.

## Related PRs
<!-- Mention any other pull requests that need to be merged (and in which order, if applicable). -->
<!--If your PR is related to an issue, you can close the issue by using keywords: https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- For example, just write: Closes #31 -->

Related to #23 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
