### PR TITLE
[Feature] Support direct child/parent classes queries

### DIFF
--- a/common/mas_knowledge_utils/ontology_query_interface.py
+++ b/common/mas_knowledge_utils/ontology_query_interface.py
@@ -143,34 +143,40 @@ class OntologyQueryInterface(object):
         else:
             raise ValueError('"{0}" does not exist as a class in the ontology!'.format(class_name))
 
-    def get_subclasses_of(self, class_name):
+    def get_subclasses_of(self, class_name, only_children=False):
         '''Returns a list of all subclasses of 'class_name'.
 
         Keyword arguments:
         @param class_name -- string representing the name of a class
+        @param only_children -- boolean if set to True, only the immediate 
+                                children of class_name will be returned
 
         '''
         if self.is_class(class_name):
             rdf_class_uri = rdflib.URIRef(self.__format_class_name(class_name))
-            query_result = self.knowledge_graph.transitive_subjects(rdflib.RDFS.subClassOf,
-                                                                    rdf_class_uri)
+            query_func = self.knowledge_graph.subjects if only_children else \
+                         self.knowledge_graph.transitive_subjects
+            query_result = query_func(rdflib.RDFS.subClassOf, rdf_class_uri)
             subclasses = [self.__extract_class_name(subclass)
                           for subclass in [str(x) for x in query_result]]
             return subclasses
         else:
             raise ValueError('"{0}" does not exist as a class in the ontology!'.format(class_name))
 
-    def get_parent_classes_of(self, class_name):
+    def get_parent_classes_of(self, class_name, only_parents=False):
         '''Returns a list of all parent classes of 'class_name'.
 
         Keyword arguments:
         @param class_name -- string representing the name of a class
+        @param only_parents -- boolean if set to True, only the immediate 
+                               parents of class_name will be returned
 
         '''
         if self.is_class(class_name):
             rdf_class_uri = rdflib.URIRef(self.__format_class_name(class_name))
-            query_result = self.knowledge_graph.transitive_objects(rdf_class_uri,
-                                                                   rdflib.RDFS.subClassOf)
+            query_func = self.knowledge_graph.objects if only_parents else \
+                         self.knowledge_graph.transitive_objects
+            query_result = query_func(rdf_class_uri, rdflib.RDFS.subClassOf)
             parent_classes = [self.__extract_class_name(parent_class)
                               for parent_class in [str(x) for x in query_result]]
             return parent_classes

--- a/common/tests/ontology_query_interface_unit_tests.py
+++ b/common/tests/ontology_query_interface_unit_tests.py
@@ -68,9 +68,25 @@ class ontology_query_interface_test(unittest.TestCase):
         acquired_data = self.ont_if.get_subclasses_of("Furniture")
         self.assertEqual(acquired_data, validation_data)
 
+        validation_data = ['Table']
+        acquired_data = self.ont_if.get_subclasses_of("Furniture", only_children=True)
+        self.assertEqual(acquired_data, validation_data)
+
+        validation_data = ['Drinkware', 'Furniture']
+        acquired_data = sorted(self.ont_if.get_subclasses_of("Object", only_children=True))
+        self.assertEqual(acquired_data, validation_data)
+
     def test_get_parent_classes_of(self):
         validation_data = ['Table', 'Furniture', 'Object']
         acquired_data = self.ont_if.get_parent_classes_of("Table")
+        self.assertEqual(acquired_data, validation_data)
+
+        validation_data = ['Furniture']
+        acquired_data = self.ont_if.get_parent_classes_of("Table", only_parents=True)
+        self.assertEqual(acquired_data, validation_data)
+
+        validation_data = []
+        acquired_data = self.ont_if.get_parent_classes_of("Object", only_parents=True)
         self.assertEqual(acquired_data, validation_data)
 
     def test_get_objects_of(self):


### PR DESCRIPTION
This PR extends the `get_subclasses_of` and `get_parent_classes_of`APIs of the OntologyQueryInterface to support returning only the immediate parent/child classes depending on an additional boolean parameter.

## Changelog
<!-- Add a list of bullets with the summary of your changes -->
<!-- Try to use infinitives: Fix, Remove, Rename, Add, Refactor -->

* Added `only_children`/`only_parents` parameters to the `get_subclasses_of` and `get_parent_classes_of`APIs repectively
* Extended the unit tests to test the new parameters

## Related PRs
<!-- Mention any other pull requests that need to be merged (and in which order, if applicable). -->
<!--If your PR is related to an issue, you can close the issue by using keywords: https://help.github.com/en/articles/closing-issues-using-keywords -->
<!-- For example, just write: Closes #31 -->

Closes #27  

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code doesn't contain unnecessary comment blocks (e.g. unused code, templates of `package.xml` or `CMakeLists.txt`)
- [x] I have updated the `package.xml` and `CMakeLists.txt` with the correct dependencies.
- [x] I have updated the documentation accordingly.

<!-- Click on the preview button to make sure everything is correctly formatted -->
