### PR TITLE
Retrieving objects within a given distance from a robot

### DIFF
--- a/ros/src/mas_knowledge_base/knowledge_base_interface.py
+++ b/ros/src/mas_knowledge_base/knowledge_base_interface.py
@@ -263,6 +263,20 @@ class KnowledgeBaseInterface(object):
         '''
         self.msg_store_client.delete_named(obj_name, obj_type)
 
+    def get_all_objects(self, obj_type):
+        '''Returns a list of all objects of the given type:
+
+        Keyword arguments:
+        @param obj_type: str -- type of the objects to be retrieved
+
+        '''
+        try:
+            objects, _ = self.msg_store_client.query(obj_type)
+            return objects
+        except:
+            rospy.logerr('[kb_interface] Error retrieving knowledge about objects of type %s', obj_type)
+            return []
+
     def get_objects(self, object_names, obj_type):
         '''Returns a list of named object instances from the knowledge base.
 


### PR DESCRIPTION
Addresses https://github.com/b-it-bots/mas_knowledge_base/issues/30

The PR adds two new functions:
* in the generic KB interface, a function `get_all_objects` is added, which returns all objects of a given type in the knowledge base
* in the domestic KB interface, a function `get_objects_within_distance` is added, which returns all objects of a given type that are within a given distance from a robot