### PR TITLE
KB instances

### DIFF
--- a/ros/scripts/export_ontology_to_kb
+++ b/ros/scripts/export_ontology_to_kb
@@ -40,6 +40,7 @@ class OntologyExporter(object):
         '''
         object_properties = self.ont_query_interface.get_object_properties()
         facts_to_add = []
+        instances_to_add = []
         for obj_property in object_properties:
             (prop_domain, prop_range) = self.ont_query_interface.get_property_domain_range(obj_property)
             subj_obj_pairs = self.ont_query_interface.get_all_subjects_and_objects(obj_property)
@@ -59,8 +60,24 @@ class OntologyExporter(object):
                     else:
                         fact = [obj_property, [(prop_domain + '0', subj),
                                                (prop_range + '1', obj)]]
+
+                    subj_instance = (prop_domain, subj)
+                    obj_instance = (prop_range, obj)
+
+                    if subj_instance not in instances_to_add:
+                        instances_to_add.append(subj_instance)
+                    if obj_instance not in instances_to_add:
+                        instances_to_add.append(obj_instance)
+
                 facts_to_add.append(fact)
+
+        print('Inserting instances')
+        self.kb_interface.insert_instances(instances_to_add)
+
+        print('Inserting facts')
         self.kb_interface.insert_facts(facts_to_add)
+
+        print('Ontology export complete')
 
 if __name__ == '__main__':
     rospy.init_node('ontology_exporter')

--- a/ros/src/mas_knowledge_base/knowledge_base_interface.py
+++ b/ros/src/mas_knowledge_base/knowledge_base_interface.py
@@ -120,6 +120,48 @@ class KnowledgeBaseInterface(object):
         rospy.loginfo('[kb_interface] Removing facts from the knowledge base')
         self.remove_facts(facts_to_remove)
 
+    def insert_instances(self, instances):
+        '''Inserts the given instances into the knowledge base.
+
+        Keyword arguments:
+        @param instances: Sequence[(str, str)] -- instances to be inserted; each instance
+                                                  is represented as a tuple of the format
+                                                  (instance_type, instance_name)
+
+        '''
+        try:
+            for (instance_type, instance_name) in instances:
+                request = rosplan_srvs.KnowledgeUpdateServiceRequest()
+                request.update_type = KnowledgeUpdateTypes.INSERT
+                request.knowledge.knowledge_type = 0
+                request.knowledge.instance_type = instance_type
+                request.knowledge.instance_name = instance_name
+                self.knowledge_update_client(request)
+        except Exception as exc:
+            rospy.logerr('[kb_interface] %s', str(exc))
+            raise KBException('Instances could not be inserted into the knowledge base')
+
+    def remove_instances(self, instances):
+        '''Removes the given instances from the knowledge base.
+
+        Keyword arguments:
+        @param instances: Sequence[(str, str)] -- instances to be removed; each instance
+                                                  is represented as a tuple of the format
+                                                  (instance_type, instance_name)
+
+        '''
+        try:
+            for (instance_type, instance_name) in instances:
+                request = rosplan_srvs.KnowledgeUpdateServiceRequest()
+                request.update_type = KnowledgeUpdateTypes.REMOVE
+                request.knowledge.knowledge_type = 0
+                request.knowledge.instance_type = instance_type
+                request.knowledge.instance_name = instance_name
+                self.knowledge_update_client(request)
+        except Exception as exc:
+            rospy.logerr('[kb_interface] %s', str(exc))
+            raise KBException('Instances could not be removed from the knowledge base')
+
     def insert_facts(self, fact_list):
         '''Inserts the facts in the given list into the knowledge base.
 


### PR DESCRIPTION
## Summary of changes

This PR makes two modifications related to the knowledge base interface:
* functions for adding and removing object instances are added to the interface
* using the insertion function, the ontology-to-KB export script is now also adding the object instances to the knowledge base

## Necessity for changes

These changes fix a problem with the ROSPlan problem generation: without adding the object instances to the knowledge base, the `objects` section of the problem file was not filled out, so the generated problem file was incomplete/invalid.