### PR TITLE
[Ontology to KB] Prevent instances from belonging to multiple classes

### DIFF
--- a/common/mas_knowledge_utils/ontology_query_interface.py
+++ b/common/mas_knowledge_utils/ontology_query_interface.py
@@ -116,6 +116,36 @@ class OntologyQueryInterface(object):
             return obj_name in self.get_instances_of(class_name)
         return False
 
+    def is_subclass_of(self, class1, class2):
+        '''Returns True if class1 is a subclass of class2; returns False otherwise.
+        Raises a ValueError if either class1 or class2 is not a valid class in the ontology.
+
+        Keyword arguments:
+        class1: str -- name of a class
+        class2: str -- name of a hypothesised parent class
+
+        '''
+        if not self.is_class(class1):
+            raise ValueError('"{0}" does not exist as a class in the ontology!'.format(class1))
+        if not self.is_class(class2):
+            raise ValueError('"{0}" does not exist as a class in the ontology!'.format(class2))
+        return class1 in self.get_subclasses_of(class2)
+
+    def is_parent_class_of(self, class1, class2):
+        '''Returns True if class1 is a parent class of class2; returns False otherwise.
+        Raises a ValueError if either class1 or class2 is not a valid class in the ontology.
+
+        Keyword arguments:
+        class1: str -- name of a class
+        class2: str -- name of a hypothesised subclass
+
+        '''
+        if not self.is_class(class1):
+            raise ValueError('"{0}" does not exist as a class in the ontology!'.format(class1))
+        if not self.is_class(class2):
+            raise ValueError('"{0}" does not exist as a class in the ontology!'.format(class2))
+        return class2 in self.get_subclasses_of(class1)
+
     def get_class_hierarchy(self):
         '''Returns a dictionary in which each key is a class and the value
         is a list of subclasses of that class. The dictionary thus represents
@@ -153,7 +183,7 @@ class OntologyQueryInterface(object):
 
         Keyword arguments:
         @param class_name -- string representing the name of a class
-        @param only_children -- boolean if set to True, only the immediate 
+        @param only_children -- boolean if set to True, only the immediate
                                 children of class_name will be returned
 
         '''
@@ -173,7 +203,7 @@ class OntologyQueryInterface(object):
 
         Keyword arguments:
         @param class_name -- string representing the name of a class
-        @param only_parents -- boolean if set to True, only the immediate 
+        @param only_parents -- boolean if set to True, only the immediate
                                parents of class_name will be returned
 
         '''
@@ -196,8 +226,8 @@ class OntologyQueryInterface(object):
 
         Keyword arguments:
         @param prop -- string representing the name of a property
-        @param object -- string representing an entity in the ontology. 
-                         This could either be an instance of a class or a value 
+        @param object -- string representing an entity in the ontology.
+                         This could either be an instance of a class or a value
                          of a specific data-type (such as a float).
 
         '''
@@ -284,7 +314,7 @@ class OntologyQueryInterface(object):
             raise ValueError('"{0}" does not exist as a property in the ontology!'.format(prop))
 
     def get_property_types(self, prop):
-        '''Returns a list that specifies the types (such as FunctionalProperty) 
+        '''Returns a list that specifies the types (such as FunctionalProperty)
         defined for the property.
 
         Keyword arguments:
@@ -303,7 +333,7 @@ class OntologyQueryInterface(object):
             raise ValueError('"{0}" does not exist as a property in the ontology!'.format(prop))
 
     def get_associated_properties(self, class_name):
-        '''Returns a list of properties that contain the class name either as 
+        '''Returns a list of properties that contain the class name either as
         the domain or the range of the property.
 
         Keyword arguments:
@@ -318,8 +348,8 @@ class OntologyQueryInterface(object):
         return associated_properties
 
     def insert_class_definition(self, class_name, parent_class_names=[]):
-        '''Defines a new class in the ontology. If the class_name already exists, 
-        and new parent classes are passed, only the sub_class relations between 
+        '''Defines a new class in the ontology. If the class_name already exists,
+        and new parent classes are passed, only the sub_class relations between
         the class_name and new parent classes are established.
 
         Keyword arguments:
@@ -343,7 +373,7 @@ class OntologyQueryInterface(object):
             self.knowledge_graph.add((class_uri, rdflib.RDFS.subClassOf,
                                       parent_class_uri))
 
-        # Reset class names list to ensure that the newly added 
+        # Reset class names list to ensure that the newly added
         # class is included in the next query to the class_list
         self.__class_names = None
 
@@ -354,10 +384,10 @@ class OntologyQueryInterface(object):
         Keyword arguments:
         property_name -- string representing the name of the new property
         domain -- string representing the domain of the new property
-        range -- string representing the range of the new property. 
+        range -- string representing the range of the new property.
                  This could be a class or a data type (such as float)
-        prop_type -- string/None representing the type (such as FunctionalProperty). 
-                     If 'None', the property will have only the default ObjectProperty 
+        prop_type -- string/None representing the type (such as FunctionalProperty).
+                     If 'None', the property will have only the default ObjectProperty
                      type and no additional type will be added.
         domain_ns -- string representing the optional namespace for the domain.
                      By default the class_prefix is used as the namespace.
@@ -392,7 +422,7 @@ class OntologyQueryInterface(object):
                 self.knowledge_graph.add((prop_uri, URIRefConstants.RDF_TYPE,
                                           prop_type_uri))
 
-            # Reset property names list to ensure that the newly added 
+            # Reset property names list to ensure that the newly added
             # property is included in the next query to the property_list
             self.__property_names = None
 
@@ -420,7 +450,7 @@ class OntologyQueryInterface(object):
         Keyword arguments:
         property_name -- string representing the name of the predicate
         instance -- tuple(string, string) representing the subject and the object respectively.
-                    While the subject has to be an instance of a class, the object could be 
+                    While the subject has to be an instance of a class, the object could be
                     an instance of a class or a value of a data-type (such as float)
 
         '''
@@ -434,9 +464,9 @@ class OntologyQueryInterface(object):
                                       rdflib.URIRef(self.__get_entity_url(instance[1]))))
 
     def remove_class_definition(self, class_name):
-        '''Removes an existing class from the ontology. 
-        Additionally, also removes all instances of this class and 
-        all property definitions which contain this class as domain/range and 
+        '''Removes an existing class from the ontology.
+        Additionally, also removes all instances of this class and
+        all property definitions which contain this class as domain/range and
         all their assertions
 
         Keyword arguments:
@@ -479,7 +509,7 @@ class OntologyQueryInterface(object):
         self.__verbose('Class "{0}" successfully removed from ontology'.format(class_name))
 
     def remove_property_definition(self, property_name):
-        '''Removes an existing property from the ontology 
+        '''Removes an existing property from the ontology
         along with all its assertions
 
         Keyword arguments:
@@ -527,7 +557,7 @@ class OntologyQueryInterface(object):
         Keyword arguments:
         property_name -- string representing the name of the predicate
         instance -- tuple(string, string) representing the subject and the object respectively.
-                    While the subject has to be an instance of a class, the object could be 
+                    While the subject has to be an instance of a class, the object could be
                     an instance of a class or a value of a data-type (such as float)
 
         '''
@@ -602,14 +632,14 @@ class OntologyQueryInterface(object):
             return rdflib.URIRef(self.__get_entity_url(entity))
 
     def __extract_class_name(self, rdf_class, delimiter=':'):
-        '''Extracts the name of a class given a string of the format 
-        "class_prefix:class_name" or "class_prefix#class_name". 
-        However, if the rdf_class is a URL the function returns the last 
+        '''Extracts the name of a class given a string of the format
+        "class_prefix:class_name" or "class_prefix#class_name".
+        However, if the rdf_class is a URL the function returns the last
         element in the URL as the class name
 
         Keyword arguments:
         @param rdf_class -- string of the form "prefix:class"
-        @param delimiter -- char representing the delimiter between the 
+        @param delimiter -- char representing the delimiter between the
                             class_prefix and the class_name
 
         '''
@@ -629,7 +659,7 @@ class OntologyQueryInterface(object):
         return obj_url[obj_url.rfind('/')+1:]
 
     def __is_url(self, rdf_class):
-        '''Returns True if the rdf_class is specified as a URL and False if the 
+        '''Returns True if the rdf_class is specified as a URL and False if the
         rdf_class is specified in the form of class_prefix:class_name
 
         Keyword arguments:

--- a/common/tests/ontology_query_interface_unit_tests.py
+++ b/common/tests/ontology_query_interface_unit_tests.py
@@ -25,7 +25,7 @@ class ontology_query_interface_test(unittest.TestCase):
                                              class_prefix=self.ontology_ns)
 
     def test_get_classes(self):
-        validation_data = ['Drinkware', 'Furniture', 'Location', 'Mug', 
+        validation_data = ['Drinkware', 'Furniture', 'Location', 'Mug',
                            'Object', 'Room', 'Table', 'WorkTable']
         acquired_data = sorted(self.ont_if.get_classes())
         self.assertEqual(acquired_data, validation_data)
@@ -44,6 +44,14 @@ class ontology_query_interface_test(unittest.TestCase):
         self.assertTrue(self.ont_if.is_instance_of("CoffeeMug", "Mug"))
         self.assertFalse(self.ont_if.is_instance_of("Desk", "Mug"))
 
+    def test_is_subclass_of(self):
+        self.assertTrue(self.ont_if.is_subclass_of("Room", "Location"))
+        self.assertFalse(self.ont_if.is_subclass_of("Room", "Object"))
+
+    def test_is_parent_class_of(self):
+        self.assertTrue(self.ont_if.is_parent_class_of("Location", "Room"))
+        self.assertFalse(self.ont_if.is_parent_class_of("Object", "Room"))
+
     def test_get_class_hierarchy(self):
         validation_data = {'Drinkware': ['Mug'], 'Mug': [], 'WorkTable': [],
                            'Table': ['WorkTable'], 'Location': ['Room'],
@@ -55,7 +63,7 @@ class ontology_query_interface_test(unittest.TestCase):
                          sorted(list(validation_data.keys())))
 
         for class_name in acquired_data.keys():
-            self.assertEqual(sorted(acquired_data[class_name]), 
+            self.assertEqual(sorted(acquired_data[class_name]),
                              validation_data[class_name])
 
     def test_get_instances_of(self):
@@ -201,7 +209,7 @@ class ontology_query_interface_test(unittest.TestCase):
         self.assertTrue(self.ont_if.is_property(prop_2_name))
 
         # Validate the domain-range of the properties
-        self.assertEqual(("Object", "Location"), 
+        self.assertEqual(("Object", "Location"),
                          self.ont_if.get_property_domain_range(prop_1_name))
         self.assertEqual(("Object", "float"),
                          self.ont_if.get_property_domain_range(prop_2_name))

--- a/ros/scripts/export_ontology_to_kb
+++ b/ros/scripts/export_ontology_to_kb
@@ -61,13 +61,10 @@ class OntologyExporter(object):
                         fact = [obj_property, [(prop_domain + '0', subj),
                                                (prop_range + '1', obj)]]
 
-                    subj_instance = (prop_domain, subj)
-                    obj_instance = (prop_range, obj)
-
-                    if subj_instance not in instances_to_add:
-                        instances_to_add.append(subj_instance)
-                    if obj_instance not in instances_to_add:
-                        instances_to_add.append(obj_instance)
+                    instances_to_add = self.update_instance_in_list(subj, prop_domain,
+                                                                    instances_to_add)
+                    instances_to_add = self.update_instance_in_list(obj, prop_range,
+                                                                    instances_to_add)
 
                 facts_to_add.append(fact)
 
@@ -78,6 +75,43 @@ class OntologyExporter(object):
         self.kb_interface.insert_facts(facts_to_add)
 
         print('Ontology export complete')
+
+    def update_instance_in_list(self, instance, instance_type, instance_list):
+        '''Inserts or updates "instance" in "instance_list". In particular:
+        * returns "instance_list" if an entry (instance_type, instance) already exists
+        * returns an updated "instance_list" otherwise:
+            * if "instance" already exists in an entry in "instance_list", but the types
+              are different, takes the more specific type as the type of "instance" if
+              the types are in a ancestor/descendant relation. If the types are disjoint,
+              keeps the already existing type of "instance"
+            * if "instance" does not exist in any entry, a new entry
+            (instance_list, instance) is added to "instance_list"
+
+        Keyword arguments:
+        @param instance: str -- name of an instance in the ontology
+        @param instance_type: str -- type of "instance"
+        @param instance_list: Sequence[Tuple[str, str]] -- list of (type, instance) tuples
+
+        '''
+        if (instance_type, instance) in instance_list:
+            return instance_list
+
+        instance_inserted = False
+        for i, (inst_type, inst) in enumerate(instance_list):
+            if inst == instance:
+                if self.ont_query_interface.is_subclass_of(instance_type, inst_type):
+                    instance_list[i] = (instance_type, inst)
+                    instance_inserted = True
+                elif self.ont_query_interface.is_subclass_of(inst_type, instance_type):
+                    instance_list[i] = (inst_type, inst)
+                    instance_inserted = True
+                else:
+                    print('WARNING: {0} exists as an instance of two unrelated classes {1} and {2}'.format(inst, instance_type, inst_type))
+                    print('WARNING: Only exporting type {0}'.format(inst_type))
+
+        if not instance_inserted:
+            instance_list.append((instance_type, instance))
+        return instance_list
 
 if __name__ == '__main__':
     rospy.init_node('ontology_exporter')


### PR DESCRIPTION
This PR fixes a small problem during the export of ontology instances to the planning knowledge base (introduced with https://github.com/b-it-bots/mas_knowledge_base/pull/32): instances that appear in multiple relations through different classes (e.g. `Object` and `Furniture`) were added to the knowledge base multiple times, which then makes the generated problem file invalid.

In this fixed version, an instance is only added to the knowledge base once with the most specific type, such that the type hierarchy is assumed to be defined in the domain definition and to match the hierarchy of the ontology classes.

Two utility functions were also added to the ontology query interface to simplify the type hierarchy checks:
* `is_subclass_of`: checks if a class is a subclass of another class
* `is_parent_class_of`: checks is a class is a parent of another class

Unit tests for these functions have also been added to the test script of the ontology query interface.