### PR TITLE
[domestic_kb_interface] Added a function for recognising people given…

### DIFF
--- a/ros/src/mas_knowledge_base/domestic_kb_interface.py
+++ b/ros/src/mas_knowledge_base/domestic_kb_interface.py
@@ -364,9 +364,9 @@ class DomesticKBInterface(KnowledgeBaseInterface):
         unknown_person_embedding = np.array(unknown_person.face.views[0].embedding.embedding)
         embedding_distances = np.zeros(len(known_people))
         for i, known_person in enumerate(known_people):
-            distance = np.linalg.norm(np.array(known_person.face.views[0].embedding.embedding) - \
-                                      unknown_person_embedding)
-            embedding_distances[i] = distance
+            person_distances = [np.linalg.norm(np.array(view.embedding.embedding) - unknown_person_embedding)
+                                for view in known_person.face.views]
+            embedding_distances[i] = np.mean(person_distances)
         min_distance_idx = np.argmin(embedding_distances)
         if embedding_distances[min_distance_idx] < recognition_threshold:
             return known_people[min_distance_idx]


### PR DESCRIPTION
Related to https://github.com/b-it-bots/mas_domestic_robotics/pull/233 and https://github.com/b-it-bots/mas_knowledge_base/pull/38

The PR adds a new `recognise_person` function to domestic KB interface, which compares the face embeddings of known people with the embedding of the person to recognise. A person is considered recognised if the distance between the embeddings is below a predefined threshold. In case of multiple views of a known person, the average distance of the embeddings is used during thresholding.