### PR TITLE
End-of-2020 stable version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.com/b-it-bots/mas_knowledge_base.svg?branch=master)](https://travis-ci.com/github/b-it-bots/mas_knowledge_base)
+
 # ``mas_knowledge_base``
 
 # Table of Contents

--- a/common/mas_knowledge_utils/ontology_query_interface.py
+++ b/common/mas_knowledge_utils/ontology_query_interface.py
@@ -116,6 +116,36 @@ class OntologyQueryInterface(object):
             return obj_name in self.get_instances_of(class_name)
         return False
 
+    def is_subclass_of(self, class1, class2):
+        '''Returns True if class1 is a subclass of class2; returns False otherwise.
+        Raises a ValueError if either class1 or class2 is not a valid class in the ontology.
+
+        Keyword arguments:
+        class1: str -- name of a class
+        class2: str -- name of a hypothesised parent class
+
+        '''
+        if not self.is_class(class1):
+            raise ValueError('"{0}" does not exist as a class in the ontology!'.format(class1))
+        if not self.is_class(class2):
+            raise ValueError('"{0}" does not exist as a class in the ontology!'.format(class2))
+        return class1 in self.get_subclasses_of(class2)
+
+    def is_parent_class_of(self, class1, class2):
+        '''Returns True if class1 is a parent class of class2; returns False otherwise.
+        Raises a ValueError if either class1 or class2 is not a valid class in the ontology.
+
+        Keyword arguments:
+        class1: str -- name of a class
+        class2: str -- name of a hypothesised subclass
+
+        '''
+        if not self.is_class(class1):
+            raise ValueError('"{0}" does not exist as a class in the ontology!'.format(class1))
+        if not self.is_class(class2):
+            raise ValueError('"{0}" does not exist as a class in the ontology!'.format(class2))
+        return class2 in self.get_subclasses_of(class1)
+
     def get_class_hierarchy(self):
         '''Returns a dictionary in which each key is a class and the value
         is a list of subclasses of that class. The dictionary thus represents
@@ -153,7 +183,7 @@ class OntologyQueryInterface(object):
 
         Keyword arguments:
         @param class_name -- string representing the name of a class
-        @param only_children -- boolean if set to True, only the immediate 
+        @param only_children -- boolean if set to True, only the immediate
                                 children of class_name will be returned
 
         '''
@@ -173,7 +203,7 @@ class OntologyQueryInterface(object):
 
         Keyword arguments:
         @param class_name -- string representing the name of a class
-        @param only_parents -- boolean if set to True, only the immediate 
+        @param only_parents -- boolean if set to True, only the immediate
                                parents of class_name will be returned
 
         '''
@@ -196,8 +226,8 @@ class OntologyQueryInterface(object):
 
         Keyword arguments:
         @param prop -- string representing the name of a property
-        @param object -- string representing an entity in the ontology. 
-                         This could either be an instance of a class or a value 
+        @param object -- string representing an entity in the ontology.
+                         This could either be an instance of a class or a value
                          of a specific data-type (such as a float).
 
         '''
@@ -284,7 +314,7 @@ class OntologyQueryInterface(object):
             raise ValueError('"{0}" does not exist as a property in the ontology!'.format(prop))
 
     def get_property_types(self, prop):
-        '''Returns a list that specifies the types (such as FunctionalProperty) 
+        '''Returns a list that specifies the types (such as FunctionalProperty)
         defined for the property.
 
         Keyword arguments:
@@ -303,7 +333,7 @@ class OntologyQueryInterface(object):
             raise ValueError('"{0}" does not exist as a property in the ontology!'.format(prop))
 
     def get_associated_properties(self, class_name):
-        '''Returns a list of properties that contain the class name either as 
+        '''Returns a list of properties that contain the class name either as
         the domain or the range of the property.
 
         Keyword arguments:
@@ -318,8 +348,8 @@ class OntologyQueryInterface(object):
         return associated_properties
 
     def insert_class_definition(self, class_name, parent_class_names=[]):
-        '''Defines a new class in the ontology. If the class_name already exists, 
-        and new parent classes are passed, only the sub_class relations between 
+        '''Defines a new class in the ontology. If the class_name already exists,
+        and new parent classes are passed, only the sub_class relations between
         the class_name and new parent classes are established.
 
         Keyword arguments:
@@ -343,7 +373,7 @@ class OntologyQueryInterface(object):
             self.knowledge_graph.add((class_uri, rdflib.RDFS.subClassOf,
                                       parent_class_uri))
 
-        # Reset class names list to ensure that the newly added 
+        # Reset class names list to ensure that the newly added
         # class is included in the next query to the class_list
         self.__class_names = None
 
@@ -354,10 +384,10 @@ class OntologyQueryInterface(object):
         Keyword arguments:
         property_name -- string representing the name of the new property
         domain -- string representing the domain of the new property
-        range -- string representing the range of the new property. 
+        range -- string representing the range of the new property.
                  This could be a class or a data type (such as float)
-        prop_type -- string/None representing the type (such as FunctionalProperty). 
-                     If 'None', the property will have only the default ObjectProperty 
+        prop_type -- string/None representing the type (such as FunctionalProperty).
+                     If 'None', the property will have only the default ObjectProperty
                      type and no additional type will be added.
         domain_ns -- string representing the optional namespace for the domain.
                      By default the class_prefix is used as the namespace.
@@ -392,7 +422,7 @@ class OntologyQueryInterface(object):
                 self.knowledge_graph.add((prop_uri, URIRefConstants.RDF_TYPE,
                                           prop_type_uri))
 
-            # Reset property names list to ensure that the newly added 
+            # Reset property names list to ensure that the newly added
             # property is included in the next query to the property_list
             self.__property_names = None
 
@@ -420,7 +450,7 @@ class OntologyQueryInterface(object):
         Keyword arguments:
         property_name -- string representing the name of the predicate
         instance -- tuple(string, string) representing the subject and the object respectively.
-                    While the subject has to be an instance of a class, the object could be 
+                    While the subject has to be an instance of a class, the object could be
                     an instance of a class or a value of a data-type (such as float)
 
         '''
@@ -434,9 +464,9 @@ class OntologyQueryInterface(object):
                                       rdflib.URIRef(self.__get_entity_url(instance[1]))))
 
     def remove_class_definition(self, class_name):
-        '''Removes an existing class from the ontology. 
-        Additionally, also removes all instances of this class and 
-        all property definitions which contain this class as domain/range and 
+        '''Removes an existing class from the ontology.
+        Additionally, also removes all instances of this class and
+        all property definitions which contain this class as domain/range and
         all their assertions
 
         Keyword arguments:
@@ -479,7 +509,7 @@ class OntologyQueryInterface(object):
         self.__verbose('Class "{0}" successfully removed from ontology'.format(class_name))
 
     def remove_property_definition(self, property_name):
-        '''Removes an existing property from the ontology 
+        '''Removes an existing property from the ontology
         along with all its assertions
 
         Keyword arguments:
@@ -527,7 +557,7 @@ class OntologyQueryInterface(object):
         Keyword arguments:
         property_name -- string representing the name of the predicate
         instance -- tuple(string, string) representing the subject and the object respectively.
-                    While the subject has to be an instance of a class, the object could be 
+                    While the subject has to be an instance of a class, the object could be
                     an instance of a class or a value of a data-type (such as float)
 
         '''
@@ -602,14 +632,14 @@ class OntologyQueryInterface(object):
             return rdflib.URIRef(self.__get_entity_url(entity))
 
     def __extract_class_name(self, rdf_class, delimiter=':'):
-        '''Extracts the name of a class given a string of the format 
-        "class_prefix:class_name" or "class_prefix#class_name". 
-        However, if the rdf_class is a URL the function returns the last 
+        '''Extracts the name of a class given a string of the format
+        "class_prefix:class_name" or "class_prefix#class_name".
+        However, if the rdf_class is a URL the function returns the last
         element in the URL as the class name
 
         Keyword arguments:
         @param rdf_class -- string of the form "prefix:class"
-        @param delimiter -- char representing the delimiter between the 
+        @param delimiter -- char representing the delimiter between the
                             class_prefix and the class_name
 
         '''
@@ -629,7 +659,7 @@ class OntologyQueryInterface(object):
         return obj_url[obj_url.rfind('/')+1:]
 
     def __is_url(self, rdf_class):
-        '''Returns True if the rdf_class is specified as a URL and False if the 
+        '''Returns True if the rdf_class is specified as a URL and False if the
         rdf_class is specified in the form of class_prefix:class_name
 
         Keyword arguments:

--- a/common/ontology/apartment.owl
+++ b/common/ontology/apartment.owl
@@ -1,6 +1,5 @@
 <?xml version="1.0"?>
-<rdf:RDF xmlns="http://apartment#"
-     xml:base="http://apartment"
+<rdf:RDF 
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
@@ -8,10 +7,10 @@
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
      xmlns:apartment="http://apartment#">
     <owl:Ontology rdf:about="http://apartment"/>
-    
 
 
-    <!-- 
+
+    <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Object Properties
@@ -19,7 +18,7 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    
+
 
 
     <!-- apartment:above -->
@@ -30,13 +29,13 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Object"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:below -->
 
     <owl:ObjectProperty rdf:about="apartment:below"/>
-    
+
 
 
     <!-- apartment:canPlaceOn -->
@@ -45,7 +44,7 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Plane"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:defaultStoringLocation -->
@@ -55,7 +54,7 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Furniture"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:hasDoor -->
@@ -65,7 +64,7 @@
         <rdfs:domain rdf:resource="apartment:Furniture"/>
         <rdfs:range rdf:resource="xsd:boolean"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:inside -->
@@ -74,7 +73,7 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Object"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:isAtLocation -->
@@ -83,7 +82,7 @@
         <rdfs:domain rdf:resource="apartment:NamedPose"/>
         <rdfs:range rdf:resource="apartment:Location"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:isAtNamedPose -->
@@ -92,7 +91,7 @@
         <rdfs:domain rdf:resource="apartment:Thing"/>
         <rdfs:range rdf:resource="apartment:NamedPose"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:likelyLocation -->
@@ -101,7 +100,7 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Furniture"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:locatedAt -->
@@ -111,7 +110,7 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Location"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:onTopOf -->
@@ -120,7 +119,7 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Object"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:orientation -->
@@ -128,7 +127,7 @@
     <owl:ObjectProperty rdf:about="apartment:orientation">
         <rdfs:subPropertyOf rdf:resource="apartment:pose"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:orientationPitch -->
@@ -136,7 +135,7 @@
     <owl:ObjectProperty rdf:about="apartment:orientationPitch">
         <rdfs:subPropertyOf rdf:resource="apartment:orientation"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:orientationRoll -->
@@ -144,7 +143,7 @@
     <owl:ObjectProperty rdf:about="apartment:orientationRoll">
         <rdfs:subPropertyOf rdf:resource="apartment:orientation"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:orientationYaw -->
@@ -152,7 +151,7 @@
     <owl:ObjectProperty rdf:about="apartment:orientationYaw">
         <rdfs:subPropertyOf rdf:resource="apartment:orientation"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:pose -->
@@ -161,7 +160,7 @@
         <rdfs:domain rdf:resource="apartment:Thing"/>
         <rdfs:range rdf:resource="xsd:float"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:position -->
@@ -169,7 +168,7 @@
     <owl:ObjectProperty rdf:about="apartment:position">
         <rdfs:subPropertyOf rdf:resource="apartment:pose"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:positionX -->
@@ -177,7 +176,7 @@
     <owl:ObjectProperty rdf:about="apartment:positionX">
         <rdfs:subPropertyOf rdf:resource="apartment:position"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:positionY -->
@@ -185,7 +184,7 @@
     <owl:ObjectProperty rdf:about="apartment:positionY">
         <rdfs:subPropertyOf rdf:resource="apartment:position"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:positionZ -->
@@ -193,7 +192,7 @@
     <owl:ObjectProperty rdf:about="apartment:positionZ">
         <rdfs:subPropertyOf rdf:resource="apartment:position"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:preferredGraspingStrategy -->
@@ -202,7 +201,7 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:GraspingStrategy"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:toTheLeftOf -->
@@ -213,16 +212,16 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Object"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:toTheRightOf -->
 
     <owl:ObjectProperty rdf:about="apartment:toTheRightOf"/>
-    
 
 
-    <!-- 
+
+    <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Data properties
@@ -230,64 +229,64 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    
+
 
 
     <!-- apartment:orientation -->
 
     <owl:DatatypeProperty rdf:about="apartment:orientation"/>
-    
+
 
 
     <!-- apartment:orientationPitch -->
 
     <owl:DatatypeProperty rdf:about="apartment:orientationPitch"/>
-    
+
 
 
     <!-- apartment:orientationRoll -->
 
     <owl:DatatypeProperty rdf:about="apartment:orientationRoll"/>
-    
+
 
 
     <!-- apartment:orientationYaw -->
 
     <owl:DatatypeProperty rdf:about="apartment:orientationYaw"/>
-    
+
 
 
     <!-- apartment:pose -->
 
     <owl:DatatypeProperty rdf:about="apartment:pose"/>
-    
+
 
 
     <!-- apartment:position -->
 
     <owl:DatatypeProperty rdf:about="apartment:position"/>
-    
+
 
 
     <!-- apartment:positionX -->
 
     <owl:DatatypeProperty rdf:about="apartment:positionX"/>
-    
+
 
 
     <!-- apartment:positionY -->
 
     <owl:DatatypeProperty rdf:about="apartment:positionY"/>
-    
+
 
 
     <!-- apartment:positionZ -->
 
     <owl:DatatypeProperty rdf:about="apartment:positionZ"/>
-    
 
 
-    <!-- 
+
+    <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Classes
@@ -295,7 +294,7 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    
+
 
 
     <!-- apartment:Alcohol -->
@@ -303,7 +302,7 @@
     <owl:Class rdf:about="apartment:Alcohol">
         <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Apple -->
@@ -311,7 +310,7 @@
     <owl:Class rdf:about="apartment:Apple">
         <rdfs:subClassOf rdf:resource="apartment:Fruit"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Appliance -->
@@ -319,7 +318,7 @@
     <owl:Class rdf:about="apartment:Appliance">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Banana -->
@@ -327,7 +326,7 @@
     <owl:Class rdf:about="apartment:Banana">
         <rdfs:subClassOf rdf:resource="apartment:Fruit"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Bed -->
@@ -335,7 +334,7 @@
     <owl:Class rdf:about="apartment:Bed">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Beef -->
@@ -343,7 +342,7 @@
     <owl:Class rdf:about="apartment:Beef">
         <rdfs:subClassOf rdf:resource="apartment:Meat"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Beer -->
@@ -351,7 +350,7 @@
     <owl:Class rdf:about="apartment:Beer">
         <rdfs:subClassOf rdf:resource="apartment:Alcohol"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Bowl -->
@@ -359,7 +358,7 @@
     <owl:Class rdf:about="apartment:Bowl">
         <rdfs:subClassOf rdf:resource="apartment:Dish"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Bread -->
@@ -367,7 +366,7 @@
     <owl:Class rdf:about="apartment:Bread">
         <rdfs:subClassOf rdf:resource="apartment:Grain"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:BreadKnife -->
@@ -375,7 +374,7 @@
     <owl:Class rdf:about="apartment:BreadKnife">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Broccoli -->
@@ -383,7 +382,7 @@
     <owl:Class rdf:about="apartment:Broccoli">
         <rdfs:subClassOf rdf:resource="apartment:Vegetable"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Butter -->
@@ -391,7 +390,7 @@
     <owl:Class rdf:about="apartment:Butter">
         <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Buttermilk -->
@@ -399,7 +398,7 @@
     <owl:Class rdf:about="apartment:Buttermilk">
         <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Cabinet -->
@@ -407,7 +406,7 @@
     <owl:Class rdf:about="apartment:Cabinet">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Cereal -->
@@ -415,7 +414,7 @@
     <owl:Class rdf:about="apartment:Cereal">
         <rdfs:subClassOf rdf:resource="apartment:Grain"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Chair -->
@@ -423,7 +422,7 @@
     <owl:Class rdf:about="apartment:Chair">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Cheese -->
@@ -431,7 +430,7 @@
     <owl:Class rdf:about="apartment:Cheese">
         <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Chicken -->
@@ -439,7 +438,7 @@
     <owl:Class rdf:about="apartment:Chicken">
         <rdfs:subClassOf rdf:resource="apartment:Meat"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Colander -->
@@ -447,7 +446,7 @@
     <owl:Class rdf:about="apartment:Colander">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Computer -->
@@ -455,7 +454,7 @@
     <owl:Class rdf:about="apartment:Computer">
         <rdfs:subClassOf rdf:resource="apartment:Equipment"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Container -->
@@ -463,7 +462,7 @@
     <owl:Class rdf:about="apartment:Container">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Cookie -->
@@ -471,7 +470,7 @@
     <owl:Class rdf:about="apartment:Cookie">
         <rdfs:subClassOf rdf:resource="apartment:Snack"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:CookingUtensil -->
@@ -479,7 +478,7 @@
     <owl:Class rdf:about="apartment:CookingUtensil">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Couch -->
@@ -487,7 +486,7 @@
     <owl:Class rdf:about="apartment:Couch">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Counter -->
@@ -495,7 +494,7 @@
     <owl:Class rdf:about="apartment:Counter">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Cream -->
@@ -503,7 +502,7 @@
     <owl:Class rdf:about="apartment:Cream">
         <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Cup -->
@@ -511,7 +510,7 @@
     <owl:Class rdf:about="apartment:Cup">
         <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Cupboard -->
@@ -520,7 +519,7 @@
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
         <rdfs:subClassOf rdf:resource="apartment:ObjectContainer"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Cutlery -->
@@ -528,7 +527,7 @@
     <owl:Class rdf:about="apartment:Cutlery">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:CuttingBoard -->
@@ -536,7 +535,7 @@
     <owl:Class rdf:about="apartment:CuttingBoard">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Dairy -->
@@ -544,7 +543,7 @@
     <owl:Class rdf:about="apartment:Dairy">
         <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:DiningRoom -->
@@ -552,7 +551,7 @@
     <owl:Class rdf:about="apartment:DiningRoom">
         <rdfs:subClassOf rdf:resource="apartment:Room"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:DiningTable -->
@@ -560,7 +559,7 @@
     <owl:Class rdf:about="apartment:DiningTable">
         <rdfs:subClassOf rdf:resource="apartment:Table"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:DiningTableChair -->
@@ -568,7 +567,7 @@
     <owl:Class rdf:about="apartment:DiningTableChair">
         <rdfs:subClassOf rdf:resource="apartment:Chair"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Dish -->
@@ -576,7 +575,7 @@
     <owl:Class rdf:about="apartment:Dish">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Dishwasher -->
@@ -584,7 +583,7 @@
     <owl:Class rdf:about="apartment:Dishwasher">
         <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Drawer -->
@@ -593,7 +592,7 @@
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
         <rdfs:subClassOf rdf:resource="apartment:ObjectContainer"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:DrinkingGlass -->
@@ -601,7 +600,7 @@
     <owl:Class rdf:about="apartment:DrinkingGlass">
         <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Drinkware -->
@@ -609,7 +608,7 @@
     <owl:Class rdf:about="apartment:Drinkware">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Equipment -->
@@ -617,7 +616,7 @@
     <owl:Class rdf:about="apartment:Equipment">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:FoodContainer -->
@@ -625,7 +624,7 @@
     <owl:Class rdf:about="apartment:FoodContainer">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:FoodOrDrink -->
@@ -633,7 +632,7 @@
     <owl:Class rdf:about="apartment:FoodOrDrink">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Fork -->
@@ -641,7 +640,7 @@
     <owl:Class rdf:about="apartment:Fork">
         <rdfs:subClassOf rdf:resource="apartment:Cutlery"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Fridge -->
@@ -649,7 +648,7 @@
     <owl:Class rdf:about="apartment:Fridge">
         <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Fruit -->
@@ -657,7 +656,7 @@
     <owl:Class rdf:about="apartment:Fruit">
         <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:FryingPan -->
@@ -666,7 +665,7 @@
         <rdfs:subClassOf rdf:resource="apartment:CookingUtensil"/>
         <owl:disjointWith rdf:resource="apartment:Pot"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Furniture -->
@@ -674,7 +673,7 @@
     <owl:Class rdf:about="apartment:Furniture">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Glass -->
@@ -682,7 +681,7 @@
     <owl:Class rdf:about="apartment:Glass">
         <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Grain -->
@@ -690,7 +689,7 @@
     <owl:Class rdf:about="apartment:Grain">
         <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:GraspingStrategy -->
@@ -698,7 +697,7 @@
     <owl:Class rdf:about="apartment:GraspingStrategy">
         <rdfs:subClassOf rdf:resource="apartment:Thing"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Grater -->
@@ -706,7 +705,7 @@
     <owl:Class rdf:about="apartment:Grater">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Ham -->
@@ -714,7 +713,7 @@
     <owl:Class rdf:about="apartment:Ham">
         <rdfs:subClassOf rdf:resource="apartment:Meat"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:HandSoap -->
@@ -722,7 +721,7 @@
     <owl:Class rdf:about="apartment:HandSoap">
         <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:IceCream -->
@@ -730,7 +729,7 @@
     <owl:Class rdf:about="apartment:IceCream">
         <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Ketchup -->
@@ -738,7 +737,7 @@
     <owl:Class rdf:about="apartment:Ketchup">
         <rdfs:subClassOf rdf:resource="apartment:Sauce"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Kitchen -->
@@ -746,7 +745,7 @@
     <owl:Class rdf:about="apartment:Kitchen">
         <rdfs:subClassOf rdf:resource="apartment:Room"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:KitchenUtensil -->
@@ -754,7 +753,7 @@
     <owl:Class rdf:about="apartment:KitchenUtensil">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Knife -->
@@ -762,7 +761,7 @@
     <owl:Class rdf:about="apartment:Knife">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Laptop -->
@@ -770,7 +769,7 @@
     <owl:Class rdf:about="apartment:Laptop">
         <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Lettuce -->
@@ -778,7 +777,7 @@
     <owl:Class rdf:about="apartment:Lettuce">
         <rdfs:subClassOf rdf:resource="apartment:Vegetable"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:LivingRoom -->
@@ -786,7 +785,7 @@
     <owl:Class rdf:about="apartment:LivingRoom">
         <rdfs:subClassOf rdf:resource="apartment:Room"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Location -->
@@ -794,7 +793,7 @@
     <owl:Class rdf:about="apartment:Location">
         <rdfs:subClassOf rdf:resource="apartment:Thing"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:LunchBox -->
@@ -802,7 +801,7 @@
     <owl:Class rdf:about="apartment:LunchBox">
         <rdfs:subClassOf rdf:resource="apartment:FoodContainer"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Mayo -->
@@ -810,7 +809,7 @@
     <owl:Class rdf:about="apartment:Mayo">
         <rdfs:subClassOf rdf:resource="apartment:Sauce"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Meat -->
@@ -818,7 +817,7 @@
     <owl:Class rdf:about="apartment:Meat">
         <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:MicrowaveOven -->
@@ -826,7 +825,7 @@
     <owl:Class rdf:about="apartment:MicrowaveOven">
         <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Milk -->
@@ -834,7 +833,7 @@
     <owl:Class rdf:about="apartment:Milk">
         <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Mixer -->
@@ -842,7 +841,7 @@
     <owl:Class rdf:about="apartment:Mixer">
         <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Mug -->
@@ -850,7 +849,7 @@
     <owl:Class rdf:about="apartment:Mug">
         <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Mustard -->
@@ -858,7 +857,7 @@
     <owl:Class rdf:about="apartment:Mustard">
         <rdfs:subClassOf rdf:resource="apartment:Sauce"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:NamedPose -->
@@ -866,7 +865,7 @@
     <owl:Class rdf:about="apartment:NamedPose">
         <rdfs:subClassOf rdf:resource="apartment:Thing"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Object -->
@@ -874,7 +873,7 @@
     <owl:Class rdf:about="apartment:Object">
         <rdfs:subClassOf rdf:resource="apartment:Thing"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:ObjectContainer -->
@@ -882,7 +881,7 @@
     <owl:Class rdf:about="apartment:ObjectContainer">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Office -->
@@ -890,7 +889,7 @@
     <owl:Class rdf:about="apartment:Office">
         <rdfs:subClassOf rdf:resource="apartment:Room"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:OfficeChair -->
@@ -898,7 +897,7 @@
     <owl:Class rdf:about="apartment:OfficeChair">
         <rdfs:subClassOf rdf:resource="apartment:Chair"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:OfficeTable -->
@@ -906,7 +905,7 @@
     <owl:Class rdf:about="apartment:OfficeTable">
         <rdfs:subClassOf rdf:resource="apartment:Table"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Onion -->
@@ -914,7 +913,7 @@
     <owl:Class rdf:about="apartment:Onion">
         <rdfs:subClassOf rdf:resource="apartment:Vegetable"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Orange -->
@@ -922,7 +921,7 @@
     <owl:Class rdf:about="apartment:Orange">
         <rdfs:subClassOf rdf:resource="apartment:Fruit"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Oven -->
@@ -930,7 +929,7 @@
     <owl:Class rdf:about="apartment:Oven">
         <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Pan -->
@@ -938,7 +937,7 @@
     <owl:Class rdf:about="apartment:Pan">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Pasta -->
@@ -946,7 +945,7 @@
     <owl:Class rdf:about="apartment:Pasta">
         <rdfs:subClassOf rdf:resource="apartment:Grain"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Peanut -->
@@ -954,7 +953,7 @@
     <owl:Class rdf:about="apartment:Peanut">
         <rdfs:subClassOf rdf:resource="apartment:Snack"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Pear -->
@@ -962,7 +961,7 @@
     <owl:Class rdf:about="apartment:Pear">
         <rdfs:subClassOf rdf:resource="apartment:Fruit"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:PersonalHygieneItem -->
@@ -970,7 +969,7 @@
     <owl:Class rdf:about="apartment:PersonalHygieneItem">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Plane -->
@@ -978,7 +977,7 @@
     <owl:Class rdf:about="apartment:Plane">
         <rdfs:subClassOf rdf:resource="apartment:Thing"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Plate -->
@@ -986,7 +985,7 @@
     <owl:Class rdf:about="apartment:Plate">
         <rdfs:subClassOf rdf:resource="apartment:Dish"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Popcorn -->
@@ -994,7 +993,7 @@
     <owl:Class rdf:about="apartment:Popcorn">
         <rdfs:subClassOf rdf:resource="apartment:Grain"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Pork -->
@@ -1002,7 +1001,7 @@
     <owl:Class rdf:about="apartment:Pork">
         <rdfs:subClassOf rdf:resource="apartment:Meat"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Pot -->
@@ -1010,7 +1009,7 @@
     <owl:Class rdf:about="apartment:Pot">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:PotatoChips -->
@@ -1018,7 +1017,7 @@
     <owl:Class rdf:about="apartment:PotatoChips">
         <rdfs:subClassOf rdf:resource="apartment:Snack"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Rice -->
@@ -1026,7 +1025,7 @@
     <owl:Class rdf:about="apartment:Rice">
         <rdfs:subClassOf rdf:resource="apartment:Grain"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Robot -->
@@ -1034,7 +1033,7 @@
     <owl:Class rdf:about="apartment:Robot">
         <rdfs:subClassOf rdf:resource="apartment:Equipment"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:RollingPin -->
@@ -1042,7 +1041,7 @@
     <owl:Class rdf:about="apartment:RollingPin">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Room -->
@@ -1050,7 +1049,7 @@
     <owl:Class rdf:about="apartment:Room">
         <rdfs:subClassOf rdf:resource="apartment:Location"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Sauce -->
@@ -1058,7 +1057,7 @@
     <owl:Class rdf:about="apartment:Sauce">
         <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Shampoo -->
@@ -1066,7 +1065,7 @@
     <owl:Class rdf:about="apartment:Shampoo">
         <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:ShavingCream -->
@@ -1074,7 +1073,7 @@
     <owl:Class rdf:about="apartment:ShavingCream">
         <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Shelf -->
@@ -1082,7 +1081,7 @@
     <owl:Class rdf:about="apartment:Shelf">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:ShotGlass -->
@@ -1090,7 +1089,7 @@
     <owl:Class rdf:about="apartment:ShotGlass">
         <rdfs:subClassOf rdf:resource="apartment:DrinkingGlass"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:ShowerGel -->
@@ -1098,7 +1097,7 @@
     <owl:Class rdf:about="apartment:ShowerGel">
         <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Sideboard -->
@@ -1106,7 +1105,7 @@
     <owl:Class rdf:about="apartment:Sideboard">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Sink -->
@@ -1115,7 +1114,7 @@
         <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Snack -->
@@ -1123,7 +1122,7 @@
     <owl:Class rdf:about="apartment:Snack">
         <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Sofa -->
@@ -1131,7 +1130,7 @@
     <owl:Class rdf:about="apartment:Sofa">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:SoupPlate -->
@@ -1139,7 +1138,7 @@
     <owl:Class rdf:about="apartment:SoupPlate">
         <rdfs:subClassOf rdf:resource="apartment:Dish"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Spatula -->
@@ -1147,7 +1146,7 @@
     <owl:Class rdf:about="apartment:Spatula">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Spinach -->
@@ -1155,7 +1154,7 @@
     <owl:Class rdf:about="apartment:Spinach">
         <rdfs:subClassOf rdf:resource="apartment:Vegetable"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Spoon -->
@@ -1163,7 +1162,7 @@
     <owl:Class rdf:about="apartment:Spoon">
         <rdfs:subClassOf rdf:resource="apartment:Cutlery"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Stove -->
@@ -1171,7 +1170,7 @@
     <owl:Class rdf:about="apartment:Stove">
         <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Table -->
@@ -1180,7 +1179,7 @@
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
         <rdfs:subClassOf rdf:resource="apartment:Plane"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:TableSpoon -->
@@ -1188,7 +1187,7 @@
     <owl:Class rdf:about="apartment:TableSpoon">
         <rdfs:subClassOf rdf:resource="apartment:Cutlery"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:TeaSpoon -->
@@ -1196,13 +1195,13 @@
     <owl:Class rdf:about="apartment:TeaSpoon">
         <rdfs:subClassOf rdf:resource="apartment:Cutlery"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Thing -->
 
     <owl:Class rdf:about="apartment:Thing"/>
-    
+
 
 
     <!-- apartment:ToiletPaper -->
@@ -1210,7 +1209,7 @@
     <owl:Class rdf:about="apartment:ToiletPaper">
         <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Toothbrush -->
@@ -1218,7 +1217,7 @@
     <owl:Class rdf:about="apartment:Toothbrush">
         <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Toothpaste -->
@@ -1226,7 +1225,7 @@
     <owl:Class rdf:about="apartment:Toothpaste">
         <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:VacuumCleaner -->
@@ -1234,7 +1233,7 @@
     <owl:Class rdf:about="apartment:VacuumCleaner">
         <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Vegetable -->
@@ -1242,7 +1241,7 @@
     <owl:Class rdf:about="apartment:Vegetable">
         <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Wardrobe -->
@@ -1250,7 +1249,7 @@
     <owl:Class rdf:about="apartment:Wardrobe">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Water -->
@@ -1258,7 +1257,7 @@
     <owl:Class rdf:about="apartment:Water">
         <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:WaterBoiler -->
@@ -1266,7 +1265,7 @@
     <owl:Class rdf:about="apartment:WaterBoiler">
         <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Whisk -->
@@ -1274,7 +1273,7 @@
     <owl:Class rdf:about="apartment:Whisk">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Wine -->
@@ -1282,7 +1281,7 @@
     <owl:Class rdf:about="apartment:Wine">
         <rdfs:subClassOf rdf:resource="apartment:Alcohol"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:WineGlass -->
@@ -1290,7 +1289,7 @@
     <owl:Class rdf:about="apartment:WineGlass">
         <rdfs:subClassOf rdf:resource="apartment:DrinkingGlass"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:WoodenSpoon -->
@@ -1298,7 +1297,7 @@
     <owl:Class rdf:about="apartment:WoodenSpoon">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:WorkTable -->
@@ -1306,7 +1305,7 @@
     <owl:Class rdf:about="apartment:WorkTable">
         <rdfs:subClassOf rdf:resource="apartment:Table"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Yogurt -->
@@ -1314,22 +1313,22 @@
     <owl:Class rdf:about="apartment:Yogurt">
         <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
     </owl:Class>
-    
+
 
 
     <!-- xsd:boolean -->
 
     <owl:Class rdf:about="xsd:boolean"/>
-    
+
 
 
     <!-- xsd:float -->
 
     <owl:Class rdf:about="xsd:float"/>
-    
 
 
-    <!-- 
+
+    <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Individuals
@@ -1340,15 +1339,15 @@
     <owl:NamedIndividual rdf:about="apartment:Sideways">
         <rdf:type rdf:resource="apartment:GraspingStrategy"/>
     </owl:NamedIndividual>
-    
+
 
     <owl:NamedIndividual rdf:about="apartment:TopDown">
         <rdf:type rdf:resource="apartment:GraspingStrategy"/>
     </owl:NamedIndividual>
-    
 
 
-    <!-- 
+
+    <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // General axioms
@@ -1427,4 +1426,3 @@
 
 
 <!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
-

--- a/common/ontology/apartment.owl
+++ b/common/ontology/apartment.owl
@@ -25,6 +25,7 @@
     <!-- apartment:above -->
 
     <owl:ObjectProperty rdf:about="apartment:above">
+        <owl:inverseOf rdf:resource="apartment:below"/>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Object"/>
@@ -34,9 +35,7 @@
 
     <!-- apartment:below -->
 
-    <owl:ObjectProperty rdf:about="apartment:below">
-        <owl:inverseOf rdf:resource="file:/home/samuel/Documents/MAS/b-it-bots/mas_knowledge_base/common/ontology/apartment.owl#apartment:above"/>
-    </owl:ObjectProperty>
+    <owl:ObjectProperty rdf:about="apartment:below"/>
     
 
 
@@ -109,6 +108,7 @@
     <!-- apartment:toTheLeftOf -->
 
     <owl:ObjectProperty rdf:about="apartment:toTheLeftOf">
+        <owl:inverseOf rdf:resource="apartment:toTheRightOf"/>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Object"/>
@@ -118,21 +118,7 @@
 
     <!-- apartment:toTheRightOf -->
 
-    <owl:ObjectProperty rdf:about="apartment:toTheRightOf">
-        <owl:inverseOf rdf:resource="file:/home/samuel/Documents/MAS/b-it-bots/mas_knowledge_base/common/ontology/apartment.owl#apartment:toTheLeftOf"/>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- file:/home/samuel/Documents/MAS/b-it-bots/mas_knowledge_base/common/ontology/apartment.owl#apartment:above -->
-
-    <owl:ObjectProperty rdf:about="file:/home/samuel/Documents/MAS/b-it-bots/mas_knowledge_base/common/ontology/apartment.owl#apartment:above"/>
-    
-
-
-    <!-- file:/home/samuel/Documents/MAS/b-it-bots/mas_knowledge_base/common/ontology/apartment.owl#apartment:toTheLeftOf -->
-
-    <owl:ObjectProperty rdf:about="file:/home/samuel/Documents/MAS/b-it-bots/mas_knowledge_base/common/ontology/apartment.owl#apartment:toTheLeftOf"/>
+    <owl:ObjectProperty rdf:about="apartment:toTheRightOf"/>
     
 
 

--- a/common/ontology/apartment.owl
+++ b/common/ontology/apartment.owl
@@ -20,7 +20,7 @@
     <owl:Class rdf:about="apartment:Plane"/>
     <owl:Class rdf:about="apartment:Room"/>
     <owl:Class rdf:about="apartment:Location"/>
-    <owl:Class rdf:about="apartment:Coordinate"/>
+    <owl:Class rdf:about="apartment:NamedPose"/>
 
     <!-- Furniture items -->
     <owl:Class rdf:about="apartment:Furniture"/>
@@ -148,12 +148,18 @@
         <owl:inverseOf rdf:resource="#apartment:toTheLeftOf"/>
     </owl:ObjectProperty>
 
-    <owl:DatatypeProperty rdf:about="apartment:position">
+    <owl:ObjectProperty rdf:about="apartment:isAtNamedPose">
         <rdfs:domain rdf:resource="apartment:Thing"/>
-        <rdfs:range rdf:resource="xsd:float"/>
-    </owl:DatatypeProperty>
+        <rdfs:range rdf:resource="apartment:NamedPose"/>
+    </owl:ObjectProperty>
 
-    <owl:DatatypeProperty rdf:about="apartment:orientation">
+    <owl:ObjectProperty rdf:about="apartment:isAtLocation">
+        <rdfs:domain rdf:resource="apartment:NamedPose"/>
+        <rdfs:range rdf:resource="apartment:Location"/>
+    </owl:ObjectProperty>
+
+
+    <owl:DatatypeProperty rdf:about="apartment:pose">
         <rdfs:domain rdf:resource="apartment:Thing"/>
         <rdfs:range rdf:resource="xsd:float"/>
     </owl:DatatypeProperty>
@@ -172,6 +178,10 @@
     </owl:Class>
 
     <owl:Class rdf:about="apartment:Plane">
+        <rdfs:subClassOf rdf:resource="apartment:Thing"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="apartment:NamedPose">
         <rdfs:subClassOf rdf:resource="apartment:Thing"/>
     </owl:Class>
 
@@ -369,6 +379,14 @@
 
 
     <!--*********** Subproperty definitions ************-->
+    <owl:DatatypeProperty rdf:about="apartment:position">
+        <rdfs:subPropertyOf rdf:resource="apartment:pose"/>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="apartment:orientation">
+        <rdfs:subPropertyOf rdf:resource="apartment:pose"/>
+    </owl:DatatypeProperty>
+
     <owl:DatatypeProperty rdf:about="apartment:positionX">
         <rdfs:subPropertyOf rdf:resource="apartment:position"/>
     </owl:DatatypeProperty>

--- a/common/ontology/apartment.owl
+++ b/common/ontology/apartment.owl
@@ -18,6 +18,7 @@
     <owl:Class rdf:about="apartment:Plane"/>
     <owl:Class rdf:about="apartment:Room"/>
     <owl:Class rdf:about="apartment:Location"/>
+    <owl:Class rdf:about="apartment:Coordinate"/>
 
     <!-- Furniture items -->
     <owl:Class rdf:about="apartment:Furniture"/>
@@ -144,6 +145,16 @@
     <owl:ObjectProperty rdf:about="apartment:toTheRightOf">
         <owl:inverseOf rdf:resource="#apartment:toTheLeftOf"/>
     </owl:ObjectProperty>
+
+    <owl:DatatypeProperty rdf:about="apartment:position">
+        <rdfs:domain rdf:resource="apartment:Coordinate"/>
+        <rdfs:range rdf:resource="xsd:float"/>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="apartment:orientation">
+        <rdfs:domain rdf:resource="apartment:Coordinate"/>
+        <rdfs:range rdf:resource="xsd:float"/>
+    </owl:DatatypeProperty>
     <!--*********************************************-->
 
 
@@ -339,6 +350,33 @@
     <owl:Class rdf:about="apartment:ToiletPaper">
       <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
     </owl:Class>
+    <!--*********************************************-->
+
+
+    <!--*********** Subproperty definitions ************-->
+    <owl:DatatypeProperty rdf:about="apartment:positionX">
+        <rdfs:subPropertyOf rdf:resource="apartment:position"/>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="apartment:positionY">
+        <rdfs:subPropertyOf rdf:resource="apartment:position"/>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="apartment:positionZ">
+        <rdfs:subPropertyOf rdf:resource="apartment:position"/>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="apartment:orientationRoll">
+        <rdfs:subPropertyOf rdf:resource="apartment:orientation"/>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="apartment:orientationPitch">
+        <rdfs:subPropertyOf rdf:resource="apartment:orientation"/>
+    </owl:DatatypeProperty>
+
+    <owl:DatatypeProperty rdf:about="apartment:orientationYaw">
+        <rdfs:subPropertyOf rdf:resource="apartment:orientation"/>
+    </owl:DatatypeProperty>
     <!--*********************************************-->
 
 

--- a/common/ontology/apartment.owl
+++ b/common/ontology/apartment.owl
@@ -1,441 +1,1217 @@
-<!DOCTYPE rdf:RDF [
-    <!ENTITY owl "http://www.w3.org/2002/07/owl#">
-    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#">
-    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#">
-]>
-
-<rdf:RDF
-    xmlns:apartment="http://apartment#"
-    xmlns:owl="http://www.w3.org/2002/07/owl#"
-    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-
-    <owl:Ontology rdf:about="http://apartment" />
-
-    <!--************* Class definitions ************-->
-    <owl:Class rdf:about="apartment:Object"/>
-    <owl:Class rdf:about="apartment:Plane"/>
-    <owl:Class rdf:about="apartment:Room"/>
-    <owl:Class rdf:about="apartment:Location"/>
-
-    <!-- Furniture items -->
-    <owl:Class rdf:about="apartment:Furniture"/>
-    <owl:Class rdf:about="apartment:ObjectContainer"/>
-    <owl:Class rdf:about="apartment:Table"/>
-    <owl:Class rdf:about="apartment:DiningTable"/>
-    <owl:Class rdf:about="apartment:WorkTable"/>
-    <owl:Class rdf:about="apartment:Drawer"/>
-    <owl:Class rdf:about="apartment:Bed"/>
-    <owl:Class rdf:about="apartment:Wardrobe"/>
-    <owl:Class rdf:about="apartment:Chair"/>
-    <owl:Class rdf:about="apartment:Sofa"/>
-    <owl:Class rdf:about="apartment:Cupboard"/>
-    <owl:Class rdf:about="apartment:Sink"/>
-
-    <!-- Appliances -->
-    <owl:Class rdf:about="apartment:Appliance"/>
-    <owl:Class rdf:about="apartment:Laptop"/>
-    <owl:Class rdf:about="apartment:VacuumCleaner"/>
-    <owl:Class rdf:about="apartment:Fridge"/>
-    <owl:Class rdf:about="apartment:Oven"/>
-    <owl:Class rdf:about="apartment:MicrowaveOven"/>
-    <owl:Class rdf:about="apartment:Stove"/>
-    <owl:Class rdf:about="apartment:WaterBoiler"/>
-    <owl:Class rdf:about="apartment:Mixer"/>
-    <owl:Class rdf:about="apartment:Dishwasher"/>
-
-    <!-- Kitchen items -->
-    <owl:Class rdf:about="apartment:KitchenUtensil"/>
-    <owl:Class rdf:about="apartment:Fork"/>
-    <owl:Class rdf:about="apartment:Knife"/>
-    <owl:Class rdf:about="apartment:BreadKnife"/>
-    <owl:Class rdf:about="apartment:TableSpoon"/>
-    <owl:Class rdf:about="apartment:TeaSpoon"/>
-
-    <!-- Drinkware -->
-    <owl:Class rdf:about="apartment:Drinkware"/>
-    <owl:Class rdf:about="apartment:Cup"/>
-    <owl:Class rdf:about="apartment:Mug"/>
-    <owl:Class rdf:about="apartment:DrinkingGlass"/>
-    <owl:Class rdf:about="apartment:ShotGlass"/>
-    <owl:Class rdf:about="apartment:WineGlass"/>
-
-    <!-- Food containers -->
-    <owl:Class rdf:about="apartment:FoodContainer"/>
-    <owl:Class rdf:about="apartment:Bowl"/>
-    <owl:Class rdf:about="apartment:Plate"/>
-    <owl:Class rdf:about="apartment:SoupPlate"/>
-    <owl:Class rdf:about="apartment:LunchBox"/>
-
-    <!-- Cooking utensils -->
-    <owl:Class rdf:about="apartment:CookingUtensil"/>
-    <owl:Class rdf:about="apartment:FryingPan"/>
-    <owl:Class rdf:about="apartment:Pot"/>
-
-    <!-- Personal hygiene items -->
-    <owl:Class rdf:about="apartment:PersonalHygieneItem"/>
-    <owl:Class rdf:about="apartment:Toothbrush"/>
-    <owl:Class rdf:about="apartment:Toothpaste"/>
-    <owl:Class rdf:about="apartment:HandSoap"/>
-    <owl:Class rdf:about="apartment:Shampoo"/>
-    <owl:Class rdf:about="apartment:ShowerGel"/>
-    <owl:Class rdf:about="apartment:ShavingCream"/>
-    <owl:Class rdf:about="apartment:ToiletPaper"/>
-    <!--*********************************************-->
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://apartment#"
+     xml:base="http://apartment"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:apartment="http://apartment#">
+    <owl:Ontology rdf:about="http://apartment"/>
+    
 
 
-    <!--************ Property definitions ***********-->
-    <owl:ObjectProperty rdf:about="apartment:canPlaceOn">
-      <rdfs:domain rdf:resource="apartment:Object"/>
-      <rdfs:range rdf:resource="apartment:Plane"/>
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Object Properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- apartment:above -->
+
+    <owl:ObjectProperty rdf:about="apartment:above">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:domain rdf:resource="apartment:Object"/>
+        <rdfs:range rdf:resource="apartment:Object"/>
     </owl:ObjectProperty>
+    
+
+
+    <!-- apartment:below -->
+
+    <owl:ObjectProperty rdf:about="apartment:below">
+        <owl:inverseOf rdf:resource="file:/home/samuel/Documents/MAS/b-it-bots/mas_knowledge_base/common/ontology/apartment.owl#apartment:above"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- apartment:canPlaceOn -->
+
+    <owl:ObjectProperty rdf:about="apartment:canPlaceOn">
+        <rdfs:domain rdf:resource="apartment:Object"/>
+        <rdfs:range rdf:resource="apartment:Plane"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- apartment:defaultStoringLocation -->
 
     <owl:ObjectProperty rdf:about="apartment:defaultStoringLocation">
-        <rdf:type rdf:resource="&owl;FunctionalProperty" />
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Furniture"/>
     </owl:ObjectProperty>
+    
 
-    <owl:ObjectProperty rdf:about="apartment:locatedAt">
-        <rdf:type rdf:resource="&owl;FunctionalProperty" />
-        <rdfs:domain rdf:resource="apartment:Object"/>
-        <rdfs:range rdf:resource="apartment:Location"/>
-    </owl:ObjectProperty>
+
+    <!-- apartment:hasDoor -->
 
     <owl:ObjectProperty rdf:about="apartment:hasDoor">
-        <rdf:type rdf:resource="&owl;FunctionalProperty" />
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="apartment:Furniture"/>
         <rdfs:range rdf:resource="xsd:boolean"/>
     </owl:ObjectProperty>
+    
 
-    <owl:ObjectProperty rdf:about="apartment:likelyLocation">
-        <rdfs:domain rdf:resource="apartment:Object"/>
-        <rdfs:range rdf:resource="apartment:Furniture"/>
-    </owl:ObjectProperty>
 
-    <!-- Geometric properties -->
-    <owl:ObjectProperty rdf:about="apartment:above">
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
-        <rdfs:domain rdf:resource="apartment:Object"/>
-        <rdfs:range rdf:resource="apartment:Object"/>
-    </owl:ObjectProperty>
-
-    <owl:ObjectProperty rdf:about="apartment:below">
-        <owl:inverseOf rdf:resource="#apartment:above"/>
-    </owl:ObjectProperty>
-
-    <owl:ObjectProperty rdf:about="apartment:onTopOf">
-        <rdfs:domain rdf:resource="apartment:Object"/>
-        <rdfs:range rdf:resource="apartment:Object"/>
-    </owl:ObjectProperty>
+    <!-- apartment:inside -->
 
     <owl:ObjectProperty rdf:about="apartment:inside">
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Object"/>
     </owl:ObjectProperty>
+    
 
-    <owl:ObjectProperty rdf:about="apartment:toTheLeftOf">
-        <rdf:type rdf:resource="&owl;TransitiveProperty"/>
+
+    <!-- apartment:likelyLocation -->
+
+    <owl:ObjectProperty rdf:about="apartment:likelyLocation">
+        <rdfs:domain rdf:resource="apartment:Object"/>
+        <rdfs:range rdf:resource="apartment:Furniture"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- apartment:locatedAt -->
+
+    <owl:ObjectProperty rdf:about="apartment:locatedAt">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="apartment:Object"/>
+        <rdfs:range rdf:resource="apartment:Location"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- apartment:onTopOf -->
+
+    <owl:ObjectProperty rdf:about="apartment:onTopOf">
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Object"/>
     </owl:ObjectProperty>
+    
+
+
+    <!-- apartment:toTheLeftOf -->
+
+    <owl:ObjectProperty rdf:about="apartment:toTheLeftOf">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
+        <rdfs:domain rdf:resource="apartment:Object"/>
+        <rdfs:range rdf:resource="apartment:Object"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- apartment:toTheRightOf -->
 
     <owl:ObjectProperty rdf:about="apartment:toTheRightOf">
-        <owl:inverseOf rdf:resource="#apartment:toTheLeftOf"/>
+        <owl:inverseOf rdf:resource="file:/home/samuel/Documents/MAS/b-it-bots/mas_knowledge_base/common/ontology/apartment.owl#apartment:toTheLeftOf"/>
     </owl:ObjectProperty>
-    <!--*********************************************-->
+    
 
 
-    <!--*********** Subclass definitions ************-->
+    <!-- file:/home/samuel/Documents/MAS/b-it-bots/mas_knowledge_base/common/ontology/apartment.owl#apartment:above -->
 
-    <!-- Location subclass definitions -->
-    <owl:Class rdf:about="apartment:Room">
-        <rdfs:subClassOf rdf:resource="apartment:Location"/>
+    <owl:ObjectProperty rdf:about="file:/home/samuel/Documents/MAS/b-it-bots/mas_knowledge_base/common/ontology/apartment.owl#apartment:above"/>
+    
+
+
+    <!-- file:/home/samuel/Documents/MAS/b-it-bots/mas_knowledge_base/common/ontology/apartment.owl#apartment:toTheLeftOf -->
+
+    <owl:ObjectProperty rdf:about="file:/home/samuel/Documents/MAS/b-it-bots/mas_knowledge_base/common/ontology/apartment.owl#apartment:toTheLeftOf"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- apartment:Alcohol -->
+
+    <owl:Class rdf:about="apartment:Alcohol">
+        <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
     </owl:Class>
+    
 
-    <!-- Object subclass definitions -->
-    <owl:Class rdf:about="apartment:Furniture">
-        <rdfs:subClassOf rdf:resource="apartment:Object"/>
-    </owl:Class>
 
-    <owl:Class rdf:about="apartment:ObjectContainer">
-        <rdfs:subClassOf rdf:resource="apartment:Object"/>
-    </owl:Class>
+    <!-- apartment:Apple -->
 
-    <owl:Class rdf:about="apartment:KitchenUtensil">
-        <rdfs:subClassOf rdf:resource="apartment:Object"/>
+    <owl:Class rdf:about="apartment:Apple">
+        <rdfs:subClassOf rdf:resource="apartment:Fruit"/>
     </owl:Class>
+    
+
+
+    <!-- apartment:Appliance -->
 
     <owl:Class rdf:about="apartment:Appliance">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
+    
 
-    <owl:Class rdf:about="apartment:Drinkware">
+
+    <!-- apartment:Banana -->
+
+    <owl:Class rdf:about="apartment:Banana">
+        <rdfs:subClassOf rdf:resource="apartment:Fruit"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Bed -->
+
+    <owl:Class rdf:about="apartment:Bed">
+        <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Beef -->
+
+    <owl:Class rdf:about="apartment:Beef">
+        <rdfs:subClassOf rdf:resource="apartment:Meat"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Beer -->
+
+    <owl:Class rdf:about="apartment:Beer">
+        <rdfs:subClassOf rdf:resource="apartment:Alcohol"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Bowl -->
+
+    <owl:Class rdf:about="apartment:Bowl">
+        <rdfs:subClassOf rdf:resource="apartment:Dish"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Bread -->
+
+    <owl:Class rdf:about="apartment:Bread">
+        <rdfs:subClassOf rdf:resource="apartment:Grain"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:BreadKnife -->
+
+    <owl:Class rdf:about="apartment:BreadKnife">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Broccoli -->
+
+    <owl:Class rdf:about="apartment:Broccoli">
+        <rdfs:subClassOf rdf:resource="apartment:Vegetable"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Butter -->
+
+    <owl:Class rdf:about="apartment:Butter">
+        <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Buttermilk -->
+
+    <owl:Class rdf:about="apartment:Buttermilk">
+        <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Cabinet -->
+
+    <owl:Class rdf:about="apartment:Cabinet">
+        <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Cereal -->
+
+    <owl:Class rdf:about="apartment:Cereal">
+        <rdfs:subClassOf rdf:resource="apartment:Grain"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Chair -->
+
+    <owl:Class rdf:about="apartment:Chair">
+        <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Cheese -->
+
+    <owl:Class rdf:about="apartment:Cheese">
+        <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Chicken -->
+
+    <owl:Class rdf:about="apartment:Chicken">
+        <rdfs:subClassOf rdf:resource="apartment:Meat"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Colander -->
+
+    <owl:Class rdf:about="apartment:Colander">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Computer -->
+
+    <owl:Class rdf:about="apartment:Computer">
+        <rdfs:subClassOf rdf:resource="apartment:Equipment"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Container -->
+
+    <owl:Class rdf:about="apartment:Container">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
+    
 
-    <owl:Class rdf:about="apartment:FoodContainer">
-        <rdfs:subClassOf rdf:resource="apartment:Object"/>
+
+    <!-- apartment:Cookie -->
+
+    <owl:Class rdf:about="apartment:Cookie">
+        <rdfs:subClassOf rdf:resource="apartment:Snack"/>
     </owl:Class>
+    
+
+
+    <!-- apartment:CookingUtensil -->
 
     <owl:Class rdf:about="apartment:CookingUtensil">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
+    
+
+
+    <!-- apartment:Couch -->
+
+    <owl:Class rdf:about="apartment:Couch">
+        <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Counter -->
+
+    <owl:Class rdf:about="apartment:Counter">
+        <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Cream -->
+
+    <owl:Class rdf:about="apartment:Cream">
+        <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Cup -->
+
+    <owl:Class rdf:about="apartment:Cup">
+        <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Cupboard -->
+
+    <owl:Class rdf:about="apartment:Cupboard">
+        <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
+        <rdfs:subClassOf rdf:resource="apartment:ObjectContainer"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Cutlery -->
+
+    <owl:Class rdf:about="apartment:Cutlery">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:CuttingBoard -->
+
+    <owl:Class rdf:about="apartment:CuttingBoard">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Dairy -->
+
+    <owl:Class rdf:about="apartment:Dairy">
+        <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:DiningRoom -->
+
+    <owl:Class rdf:about="apartment:DiningRoom">
+        <rdfs:subClassOf rdf:resource="apartment:Room"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:DiningTable -->
+
+    <owl:Class rdf:about="apartment:DiningTable">
+        <rdfs:subClassOf rdf:resource="apartment:Table"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:DiningTableChair -->
+
+    <owl:Class rdf:about="apartment:DiningTableChair">
+        <rdfs:subClassOf rdf:resource="apartment:Chair"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Dish -->
+
+    <owl:Class rdf:about="apartment:Dish">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Dishwasher -->
+
+    <owl:Class rdf:about="apartment:Dishwasher">
+        <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Drawer -->
+
+    <owl:Class rdf:about="apartment:Drawer">
+        <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
+        <rdfs:subClassOf rdf:resource="apartment:ObjectContainer"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Drinkware -->
+
+    <owl:Class rdf:about="apartment:Drinkware">
+        <rdfs:subClassOf rdf:resource="apartment:Object"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Equipment -->
+
+    <owl:Class rdf:about="apartment:Equipment">
+        <rdfs:subClassOf rdf:resource="apartment:Object"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:FoodContainer -->
+
+    <owl:Class rdf:about="apartment:FoodContainer">
+        <rdfs:subClassOf rdf:resource="apartment:Object"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:FoodOrDrink -->
+
+    <owl:Class rdf:about="apartment:FoodOrDrink">
+        <rdfs:subClassOf rdf:resource="apartment:Object"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Fork -->
+
+    <owl:Class rdf:about="apartment:Fork">
+        <rdfs:subClassOf rdf:resource="apartment:Cutlery"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Fridge -->
+
+    <owl:Class rdf:about="apartment:Fridge">
+        <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Fruit -->
+
+    <owl:Class rdf:about="apartment:Fruit">
+        <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:FryingPan -->
+
+    <owl:Class rdf:about="apartment:FryingPan">
+        <rdfs:subClassOf rdf:resource="apartment:CookingUtensil"/>
+        <owl:disjointWith rdf:resource="apartment:Pot"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Furniture -->
+
+    <owl:Class rdf:about="apartment:Furniture">
+        <rdfs:subClassOf rdf:resource="apartment:Object"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Glass -->
+
+    <owl:Class rdf:about="apartment:Glass">
+        <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Grain -->
+
+    <owl:Class rdf:about="apartment:Grain">
+        <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Grater -->
+
+    <owl:Class rdf:about="apartment:Grater">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Ham -->
+
+    <owl:Class rdf:about="apartment:Ham">
+        <rdfs:subClassOf rdf:resource="apartment:Meat"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:HandSoap -->
+
+    <owl:Class rdf:about="apartment:HandSoap">
+        <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:IceCream -->
+
+    <owl:Class rdf:about="apartment:IceCream">
+        <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Ketchup -->
+
+    <owl:Class rdf:about="apartment:Ketchup">
+        <rdfs:subClassOf rdf:resource="apartment:Sauce"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Kitchen -->
+
+    <owl:Class rdf:about="apartment:Kitchen">
+        <rdfs:subClassOf rdf:resource="apartment:Room"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:KitchenUtensil -->
+
+    <owl:Class rdf:about="apartment:KitchenUtensil">
+        <rdfs:subClassOf rdf:resource="apartment:Object"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Knife -->
+
+    <owl:Class rdf:about="apartment:Knife">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Laptop -->
+
+    <owl:Class rdf:about="apartment:Laptop">
+        <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Lettuce -->
+
+    <owl:Class rdf:about="apartment:Lettuce">
+        <rdfs:subClassOf rdf:resource="apartment:Vegetable"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:LivingRoom -->
+
+    <owl:Class rdf:about="apartment:LivingRoom">
+        <rdfs:subClassOf rdf:resource="apartment:Room"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Location -->
+
+    <owl:Class rdf:about="apartment:Location"/>
+    
+
+
+    <!-- apartment:LunchBox -->
+
+    <owl:Class rdf:about="apartment:LunchBox">
+        <rdfs:subClassOf rdf:resource="apartment:FoodContainer"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Mayo -->
+
+    <owl:Class rdf:about="apartment:Mayo">
+        <rdfs:subClassOf rdf:resource="apartment:Sauce"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Meat -->
+
+    <owl:Class rdf:about="apartment:Meat">
+        <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:MicrowaveOven -->
+
+    <owl:Class rdf:about="apartment:MicrowaveOven">
+        <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Milk -->
+
+    <owl:Class rdf:about="apartment:Milk">
+        <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Mixer -->
+
+    <owl:Class rdf:about="apartment:Mixer">
+        <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Mug -->
+
+    <owl:Class rdf:about="apartment:Mug">
+        <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Mustard -->
+
+    <owl:Class rdf:about="apartment:Mustard">
+        <rdfs:subClassOf rdf:resource="apartment:Sauce"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Object -->
+
+    <owl:Class rdf:about="apartment:Object"/>
+    
+
+
+    <!-- apartment:ObjectContainer -->
+
+    <owl:Class rdf:about="apartment:ObjectContainer">
+        <rdfs:subClassOf rdf:resource="apartment:Object"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Office -->
+
+    <owl:Class rdf:about="apartment:Office">
+        <rdfs:subClassOf rdf:resource="apartment:Room"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:OfficeChair -->
+
+    <owl:Class rdf:about="apartment:OfficeChair">
+        <rdfs:subClassOf rdf:resource="apartment:Chair"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:OfficeTable -->
+
+    <owl:Class rdf:about="apartment:OfficeTable">
+        <rdfs:subClassOf rdf:resource="apartment:Table"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Onion -->
+
+    <owl:Class rdf:about="apartment:Onion">
+        <rdfs:subClassOf rdf:resource="apartment:Vegetable"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Orange -->
+
+    <owl:Class rdf:about="apartment:Orange">
+        <rdfs:subClassOf rdf:resource="apartment:Fruit"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Oven -->
+
+    <owl:Class rdf:about="apartment:Oven">
+        <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Pan -->
+
+    <owl:Class rdf:about="apartment:Pan">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Pasta -->
+
+    <owl:Class rdf:about="apartment:Pasta">
+        <rdfs:subClassOf rdf:resource="apartment:Grain"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Peanut -->
+
+    <owl:Class rdf:about="apartment:Peanut">
+        <rdfs:subClassOf rdf:resource="apartment:Snack"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Pear -->
+
+    <owl:Class rdf:about="apartment:Pear">
+        <rdfs:subClassOf rdf:resource="apartment:Fruit"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:PersonalHygieneItem -->
 
     <owl:Class rdf:about="apartment:PersonalHygieneItem">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
+    
 
-    <!-- Object container subclass definitions -->
-    <owl:Class rdf:about="apartment:Drawer">
-        <rdfs:subClassOf rdf:resource="apartment:ObjectContainer"/>
-    </owl:Class>
 
-    <owl:Class rdf:about="apartment:Cupboard">
-        <rdfs:subClassOf rdf:resource="apartment:ObjectContainer"/>
-    </owl:Class>
+    <!-- apartment:Plane -->
 
-    <!-- Furniture subclass definitions -->
-    <owl:Class rdf:about="apartment:DiningTable">
-      <rdfs:subClassOf rdf:resource="apartment:Table"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:WorkTable">
-      <rdfs:subClassOf rdf:resource="apartment:Table"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:Table">
-      <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:Table">
-      <rdfs:subClassOf rdf:resource="apartment:Plane"/>
-    </owl:Class>
+    <owl:Class rdf:about="apartment:Plane"/>
+    
 
-    <owl:Class rdf:about="apartment:Drawer">
+
+    <!-- apartment:Plate -->
+
+    <owl:Class rdf:about="apartment:Plate">
+        <rdfs:subClassOf rdf:resource="apartment:Dish"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Popcorn -->
+
+    <owl:Class rdf:about="apartment:Popcorn">
+        <rdfs:subClassOf rdf:resource="apartment:Grain"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Pork -->
+
+    <owl:Class rdf:about="apartment:Pork">
+        <rdfs:subClassOf rdf:resource="apartment:Meat"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Pot -->
+
+    <owl:Class rdf:about="apartment:Pot">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:PotatoChips -->
+
+    <owl:Class rdf:about="apartment:PotatoChips">
+        <rdfs:subClassOf rdf:resource="apartment:Snack"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Rice -->
+
+    <owl:Class rdf:about="apartment:Rice">
+        <rdfs:subClassOf rdf:resource="apartment:Grain"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Robot -->
+
+    <owl:Class rdf:about="apartment:Robot">
+        <rdfs:subClassOf rdf:resource="apartment:Equipment"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:RollingPin -->
+
+    <owl:Class rdf:about="apartment:RollingPin">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Room -->
+
+    <owl:Class rdf:about="apartment:Room">
+        <rdfs:subClassOf rdf:resource="apartment:Location"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Sauce -->
+
+    <owl:Class rdf:about="apartment:Sauce">
+        <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Shampoo -->
+
+    <owl:Class rdf:about="apartment:Shampoo">
+        <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:ShavingCream -->
+
+    <owl:Class rdf:about="apartment:ShavingCream">
+        <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Shelf -->
+
+    <owl:Class rdf:about="apartment:Shelf">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
-    <owl:Class rdf:about="apartment:Bed">
-      <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:Wardrobe">
-      <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:Chair">
-      <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:Sofa">
-      <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:Cupboard">
-      <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
-    </owl:Class>
+    
 
-    <!-- Kitchen item subclass definitions -->
-    <owl:Class rdf:about="apartment:Fork">
-      <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:Knife">
-      <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:BreadKnife">
-      <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:TableSpoon">
-      <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:TeaSpoon">
-      <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
-    </owl:Class>
 
-    <!-- Appliance subclass definitions -->
-    <owl:Class rdf:about="apartment:Laptop">
-      <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:VacuumCleaner">
-      <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:Fridge">
-      <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:Oven">
-      <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:Stove">
-      <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:MicrowaveOven">
-      <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:WaterBoiler">
-      <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:Mixer">
-      <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:Dishwasher">
-      <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
-    </owl:Class>
+    <!-- apartment:ShotGlass -->
 
-    <!-- Drinkware subclass definitions -->
-    <owl:Class rdf:about="apartment:Cup">
-      <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
+    <owl:Class rdf:about="apartment:ShotGlass">
+        <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
     </owl:Class>
-    <owl:Class rdf:about="apartment:Mug">
-      <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:DrinkingGlass">
-      <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:DrinkingGlass">
-      <rdfs:subClassOf rdf:resource="apartment:ShotGlass"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:DrinkingGlass">
-      <rdfs:subClassOf rdf:resource="apartment:WineGlass"/>
-    </owl:Class>
+    
 
-    <!-- Food container subclass definitions -->
-    <owl:Class rdf:about="apartment:Bowl">
-      <rdfs:subClassOf rdf:resource="apartment:FoodContainer"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:Plate">
-      <rdfs:subClassOf rdf:resource="apartment:FoodContainer"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:SoupPlate">
-      <rdfs:subClassOf rdf:resource="apartment:FoodContainer"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:LunchBox">
-      <rdfs:subClassOf rdf:resource="apartment:FoodContainer"/>
-    </owl:Class>
 
-    <!-- Cooking utensil subclass definitions -->
-    <owl:Class rdf:about="apartment:FryingPan">
-      <rdfs:subClassOf rdf:resource="apartment:CookingUtensil"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:Pot">
-      <rdfs:subClassOf rdf:resource="apartment:CookingUtensil"/>
-    </owl:Class>
+    <!-- apartment:ShowerGel -->
 
-    <!-- Personal hygiene subclass definitions -->
-    <owl:Class rdf:about="apartment:Toothbrush">
-      <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:Toothpaste">
-      <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:HandSoap">
-      <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
-    </owl:Class>
-    <owl:Class rdf:about="apartment:Shampoo">
-      <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
-    </owl:Class>
     <owl:Class rdf:about="apartment:ShowerGel">
-      <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
+        <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
     </owl:Class>
-    <owl:Class rdf:about="apartment:ShavingCream">
-      <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
+    
+
+
+    <!-- apartment:Sideboard -->
+
+    <owl:Class rdf:about="apartment:Sideboard">
+        <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
-    <owl:Class rdf:about="apartment:ShavingCream">
-      <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
+    
+
+
+    <!-- apartment:Sink -->
+
+    <owl:Class rdf:about="apartment:Sink">
+        <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
     </owl:Class>
+    
+
+
+    <!-- apartment:Snack -->
+
+    <owl:Class rdf:about="apartment:Snack">
+        <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Sofa -->
+
+    <owl:Class rdf:about="apartment:Sofa">
+        <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:SoupPlate -->
+
+    <owl:Class rdf:about="apartment:SoupPlate">
+        <rdfs:subClassOf rdf:resource="apartment:Dish"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Spatula -->
+
+    <owl:Class rdf:about="apartment:Spatula">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Spinach -->
+
+    <owl:Class rdf:about="apartment:Spinach">
+        <rdfs:subClassOf rdf:resource="apartment:Vegetable"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Spoon -->
+
+    <owl:Class rdf:about="apartment:Spoon">
+        <rdfs:subClassOf rdf:resource="apartment:Cutlery"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Stove -->
+
+    <owl:Class rdf:about="apartment:Stove">
+        <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Table -->
+
+    <owl:Class rdf:about="apartment:Table">
+        <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
+        <rdfs:subClassOf rdf:resource="apartment:Plane"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:TableSpoon -->
+
+    <owl:Class rdf:about="apartment:TableSpoon">
+        <rdfs:subClassOf rdf:resource="apartment:Cutlery"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:TeaSpoon -->
+
+    <owl:Class rdf:about="apartment:TeaSpoon">
+        <rdfs:subClassOf rdf:resource="apartment:Cutlery"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:ToiletPaper -->
+
     <owl:Class rdf:about="apartment:ToiletPaper">
-      <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
+        <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
     </owl:Class>
-    <!--*********************************************-->
+    
 
 
-    <!--****** Class disjointness definitions *******-->
-    <owl:AllDisjointClasses>
+    <!-- apartment:Toothbrush -->
+
+    <owl:Class rdf:about="apartment:Toothbrush">
+        <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Toothpaste -->
+
+    <owl:Class rdf:about="apartment:Toothpaste">
+        <rdfs:subClassOf rdf:resource="apartment:PersonalHygieneItem"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:VacuumCleaner -->
+
+    <owl:Class rdf:about="apartment:VacuumCleaner">
+        <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Vegetable -->
+
+    <owl:Class rdf:about="apartment:Vegetable">
+        <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Wardrobe -->
+
+    <owl:Class rdf:about="apartment:Wardrobe">
+        <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Water -->
+
+    <owl:Class rdf:about="apartment:Water">
+        <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:WaterBoiler -->
+
+    <owl:Class rdf:about="apartment:WaterBoiler">
+        <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Whisk -->
+
+    <owl:Class rdf:about="apartment:Whisk">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Wine -->
+
+    <owl:Class rdf:about="apartment:Wine">
+        <rdfs:subClassOf rdf:resource="apartment:Alcohol"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:WineGlass -->
+
+    <owl:Class rdf:about="apartment:WineGlass">
+        <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:WoodenSpoon -->
+
+    <owl:Class rdf:about="apartment:WoodenSpoon">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:WorkTable -->
+
+    <owl:Class rdf:about="apartment:WorkTable">
+        <rdfs:subClassOf rdf:resource="apartment:Table"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Yogurt -->
+
+    <owl:Class rdf:about="apartment:Yogurt">
+        <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
+    </owl:Class>
+    
+
+
+    <!-- xsd:boolean -->
+
+    <owl:Class rdf:about="xsd:boolean"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // General axioms
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <owl:Class rdf:about="apartment:Location"/>
-            <owl:Class rdf:about="apartment:Plane"/>
-            <owl:Class rdf:about="apartment:Object"/>
+            <rdf:Description rdf:about="apartment:Bed"/>
+            <rdf:Description rdf:about="apartment:Chair"/>
+            <rdf:Description rdf:about="apartment:Cupboard"/>
+            <rdf:Description rdf:about="apartment:DiningTable"/>
+            <rdf:Description rdf:about="apartment:Drawer"/>
+            <rdf:Description rdf:about="apartment:Sofa"/>
+            <rdf:Description rdf:about="apartment:Wardrobe"/>
+            <rdf:Description rdf:about="apartment:WorkTable"/>
         </owl:members>
-    </owl:AllDisjointClasses>
-
-    <owl:AllDisjointClasses>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <owl:Class rdf:about="apartment:Furniture"/>
-            <owl:Class rdf:about="apartment:KitchenUtensil"/>
-            <owl:Class rdf:about="apartment:Appliance"/>
-            <owl:Class rdf:about="apartment:Drinkware"/>
-            <owl:Class rdf:about="apartment:Foodcontainer"/>
-            <owl:Class rdf:about="apartment:CookingUtensil"/>
-            <owl:Class rdf:about="apartment:PersonalHygieneItem"/>
+            <rdf:Description rdf:about="apartment:Bowl"/>
+            <rdf:Description rdf:about="apartment:LunchBox"/>
+            <rdf:Description rdf:about="apartment:Plate"/>
+            <rdf:Description rdf:about="apartment:SoupPlate"/>
         </owl:members>
-    </owl:AllDisjointClasses>
-
-    <owl:AllDisjointClasses>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <owl:Class rdf:about="apartment:Drawer"/>
-            <owl:Class rdf:about="apartment:Bed"/>
-            <owl:Class rdf:about="apartment:Wardrobe"/>
-            <owl:Class rdf:about="apartment:Chair"/>
-            <owl:Class rdf:about="apartment:Sofa"/>
-            <owl:Class rdf:about="apartment:Cupboard"/>
-            <owl:Class rdf:about="apartment:DiningTable"/>
-            <owl:Class rdf:about="apartment:WorkTable"/>
+            <rdf:Description rdf:about="apartment:BreadKnife"/>
+            <rdf:Description rdf:about="apartment:Fork"/>
+            <rdf:Description rdf:about="apartment:Knife"/>
+            <rdf:Description rdf:about="apartment:TableSpoon"/>
+            <rdf:Description rdf:about="apartment:TeaSpoon"/>
         </owl:members>
-    </owl:AllDisjointClasses>
-
-    <owl:AllDisjointClasses>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <owl:Class rdf:about="apartment:Fork"/>
-            <owl:Class rdf:about="apartment:Knife"/>
-            <owl:Class rdf:about="apartment:BreadKnife"/>
-            <owl:Class rdf:about="apartment:TableSpoon"/>
-            <owl:Class rdf:about="apartment:TeaSpoon"/>
+            <rdf:Description rdf:about="apartment:Dishwasher"/>
+            <rdf:Description rdf:about="apartment:Fridge"/>
+            <rdf:Description rdf:about="apartment:Laptop"/>
+            <rdf:Description rdf:about="apartment:MicrowaveOven"/>
+            <rdf:Description rdf:about="apartment:Mixer"/>
+            <rdf:Description rdf:about="apartment:Oven"/>
+            <rdf:Description rdf:about="apartment:Stove"/>
+            <rdf:Description rdf:about="apartment:VacuumCleaner"/>
+            <rdf:Description rdf:about="apartment:WaterBoiler"/>
         </owl:members>
-    </owl:AllDisjointClasses>
-
-    <owl:AllDisjointClasses>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <owl:Class rdf:about="apartment:Laptop"/>
-            <owl:Class rdf:about="apartment:VacuumCleaner"/>
-            <owl:Class rdf:about="apartment:Fridge"/>
-            <owl:Class rdf:about="apartment:Oven"/>
-            <owl:Class rdf:about="apartment:MicrowaveOven"/>
-            <owl:Class rdf:about="apartment:Stove"/>
-            <owl:Class rdf:about="apartment:WaterBoiler"/>
-            <owl:Class rdf:about="apartment:Mixer"/>
-            <owl:Class rdf:about="apartment:Dishwasher"/>
+            <rdf:Description rdf:about="apartment:HandSoap"/>
+            <rdf:Description rdf:about="apartment:Shampoo"/>
+            <rdf:Description rdf:about="apartment:ShavingCream"/>
+            <rdf:Description rdf:about="apartment:ShowerGel"/>
+            <rdf:Description rdf:about="apartment:ToiletPaper"/>
+            <rdf:Description rdf:about="apartment:Toothbrush"/>
+            <rdf:Description rdf:about="apartment:Toothpaste"/>
         </owl:members>
-    </owl:AllDisjointClasses>
-
-    <owl:AllDisjointClasses>
+    </rdf:Description>
+    <rdf:Description>
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <owl:Class rdf:about="apartment:Cup"/>
-            <owl:Class rdf:about="apartment:Mug"/>
-            <owl:Class rdf:about="apartment:DrinkingGlass"/>
-            <owl:Class rdf:about="apartment:ShotGlass"/>
-            <owl:Class rdf:about="apartment:WineGlass"/>
+            <rdf:Description rdf:about="apartment:Location"/>
+            <rdf:Description rdf:about="apartment:Object"/>
+            <rdf:Description rdf:about="apartment:Plane"/>
         </owl:members>
-    </owl:AllDisjointClasses>
-
-    <owl:AllDisjointClasses>
-        <owl:members rdf:parseType="Collection">
-            <owl:Class rdf:about="apartment:Bowl"/>
-            <owl:Class rdf:about="apartment:Plate"/>
-            <owl:Class rdf:about="apartment:SoupPlate"/>
-            <owl:Class rdf:about="apartment:LunchBox"/>
-        </owl:members>
-    </owl:AllDisjointClasses>
-
-    <owl:AllDisjointClasses>
-        <owl:members rdf:parseType="Collection">
-            <owl:Class rdf:about="apartment:FryingPan"/>
-            <owl:Class rdf:about="apartment:Pot"/>
-        </owl:members>
-    </owl:AllDisjointClasses>
-
-    <owl:AllDisjointClasses>
-        <owl:members rdf:parseType="Collection">
-            <owl:Class rdf:about="apartment:Toothbrush"/>
-            <owl:Class rdf:about="apartment:Toothpaste"/>
-            <owl:Class rdf:about="apartment:HandSoap"/>
-            <owl:Class rdf:about="apartment:Shampoo"/>
-            <owl:Class rdf:about="apartment:ShowerGel"/>
-            <owl:Class rdf:about="apartment:ShavingCream"/>
-            <owl:Class rdf:about="apartment:ToiletPaper"/>
-        </owl:members>
-    </owl:AllDisjointClasses>
-    <!--*********************************************-->
+    </rdf:Description>
 </rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
+

--- a/common/ontology/apartment.owl
+++ b/common/ontology/apartment.owl
@@ -21,6 +21,7 @@
     <owl:Class rdf:about="apartment:Room"/>
     <owl:Class rdf:about="apartment:Location"/>
     <owl:Class rdf:about="apartment:NamedPose"/>
+    <owl:Class rdf:about="apartment:GraspingStrategy"/>
 
     <!-- Furniture items -->
     <owl:Class rdf:about="apartment:Furniture"/>
@@ -158,6 +159,10 @@
         <rdfs:range rdf:resource="apartment:Location"/>
     </owl:ObjectProperty>
 
+    <owl:ObjectProperty rdf:about="apartment:preferredGraspingStrategy">
+        <rdfs:domain rdf:resource="apartment:Object"/>
+        <rdfs:range rdf:resource="apartment:GraspingStrategy"/>
+    </owl:ObjectProperty>
 
     <owl:DatatypeProperty rdf:about="apartment:pose">
         <rdfs:domain rdf:resource="apartment:Thing"/>
@@ -182,6 +187,10 @@
     </owl:Class>
 
     <owl:Class rdf:about="apartment:NamedPose">
+        <rdfs:subClassOf rdf:resource="apartment:Thing"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="apartment:GraspingStrategy">
         <rdfs:subClassOf rdf:resource="apartment:Thing"/>
     </owl:Class>
 
@@ -508,5 +517,13 @@
             <owl:Class rdf:about="apartment:ToiletPaper"/>
         </owl:members>
     </owl:AllDisjointClasses>
+    <!--*********************************************-->
+
+
+    <!--****** Class assertions *******-->
+
+    <apartment:GraspingStrategy rdf:about="Sideways"/>
+    <apartment:GraspingStrategy rdf:about="TopDown"/>
+
     <!--*********************************************-->
 </rdf:RDF>

--- a/common/ontology/apartment.owl
+++ b/common/ontology/apartment.owl
@@ -14,6 +14,8 @@
     <owl:Ontology rdf:about="http://apartment" />
 
     <!--************* Class definitions ************-->
+    <owl:Class rdf:about="apartment:Thing"/>
+
     <owl:Class rdf:about="apartment:Object"/>
     <owl:Class rdf:about="apartment:Plane"/>
     <owl:Class rdf:about="apartment:Room"/>
@@ -147,18 +149,31 @@
     </owl:ObjectProperty>
 
     <owl:DatatypeProperty rdf:about="apartment:position">
-        <rdfs:domain rdf:resource="apartment:Coordinate"/>
+        <rdfs:domain rdf:resource="apartment:Thing"/>
         <rdfs:range rdf:resource="xsd:float"/>
     </owl:DatatypeProperty>
 
     <owl:DatatypeProperty rdf:about="apartment:orientation">
-        <rdfs:domain rdf:resource="apartment:Coordinate"/>
+        <rdfs:domain rdf:resource="apartment:Thing"/>
         <rdfs:range rdf:resource="xsd:float"/>
     </owl:DatatypeProperty>
     <!--*********************************************-->
 
 
     <!--*********** Subclass definitions ************-->
+
+    <!-- Thing subclass definitions -->
+    <owl:Class rdf:about="apartment:Object">
+        <rdfs:subClassOf rdf:resource="apartment:Thing"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="apartment:Location">
+        <rdfs:subClassOf rdf:resource="apartment:Thing"/>
+    </owl:Class>
+
+    <owl:Class rdf:about="apartment:Plane">
+        <rdfs:subClassOf rdf:resource="apartment:Thing"/>
+    </owl:Class>
 
     <!-- Location subclass definitions -->
     <owl:Class rdf:about="apartment:Room">

--- a/common/ontology/apartment.owl
+++ b/common/ontology/apartment.owl
@@ -273,6 +273,9 @@
     <owl:Class rdf:about="apartment:Cupboard">
       <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
+    <owl:Class rdf:about="apartment:Sink">
+      <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
+    </owl:Class>
 
     <!-- Kitchen item subclass definitions -->
     <owl:Class rdf:about="apartment:Fork">
@@ -330,11 +333,11 @@
     <owl:Class rdf:about="apartment:DrinkingGlass">
       <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
     </owl:Class>
-    <owl:Class rdf:about="apartment:DrinkingGlass">
-      <rdfs:subClassOf rdf:resource="apartment:ShotGlass"/>
+    <owl:Class rdf:about="apartment:ShotGlass">
+      <rdfs:subClassOf rdf:resource="apartment:DrinkingGlass"/>
     </owl:Class>
-    <owl:Class rdf:about="apartment:DrinkingGlass">
-      <rdfs:subClassOf rdf:resource="apartment:WineGlass"/>
+    <owl:Class rdf:about="apartment:WineGlass">
+      <rdfs:subClassOf rdf:resource="apartment:DrinkingGlass"/>
     </owl:Class>
 
     <!-- Food container subclass definitions -->

--- a/common/ontology/homelab.owl
+++ b/common/ontology/homelab.owl
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<rdf:RDF xmlns="http://b-it-bots.de/ontologies/homelab.owl"
-     xml:base="http://b-it-bots.de/ontologies/homelab.owl"
+<rdf:RDF xmlns="http://homelab#"
+     xml:base="http://homelab"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
@@ -21,7 +21,7 @@
     
 
 
-    <!--    apartment:above   -->
+    <!-- apartment:above -->
 
     <owl:ObjectProperty rdf:about="apartment:above">
         <owl:inverseOf rdf:resource="apartment:below"/>
@@ -32,13 +32,13 @@
     
 
 
-    <!--    apartment:below   -->
+    <!-- apartment:below -->
 
     <owl:ObjectProperty rdf:about="apartment:below"/>
     
 
 
-    <!--    apartment:canPlaceOn   -->
+    <!-- apartment:canPlaceOn -->
 
     <owl:ObjectProperty rdf:about="apartment:canPlaceOn">
         <rdfs:domain rdf:resource="apartment:Object"/>
@@ -47,7 +47,7 @@
     
 
 
-    <!--    apartment:closeTo   -->
+    <!-- apartment:closeTo -->
 
     <owl:ObjectProperty rdf:about="apartment:closeTo">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
@@ -57,7 +57,7 @@
     
 
 
-    <!--    apartment:closeToWall   -->
+    <!-- apartment:closeToWall -->
 
     <owl:ObjectProperty rdf:about="apartment:closeToWall">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
@@ -67,7 +67,7 @@
     
 
 
-    <!--    apartment:connectedTo   -->
+    <!-- apartment:connectedTo -->
 
     <owl:ObjectProperty rdf:about="apartment:connectedTo">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
@@ -77,7 +77,7 @@
     
 
 
-    <!--    apartment:defaultLocation   -->
+    <!-- apartment:defaultLocation -->
 
     <owl:ObjectProperty rdf:about="apartment:defaultLocation">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
@@ -87,7 +87,7 @@
     
 
 
-    <!--    apartment:hasDoor   -->
+    <!-- apartment:hasDoor -->
 
     <owl:ObjectProperty rdf:about="apartment:hasDoor">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
@@ -102,7 +102,7 @@
     
 
 
-    <!--    apartment:inside   -->
+    <!-- apartment:inside -->
 
     <owl:ObjectProperty rdf:about="apartment:inside">
         <rdfs:domain rdf:resource="apartment:Object"/>
@@ -111,16 +111,27 @@
     
 
 
-    <!--    apartment:locatedAt   -->
+    <!-- apartment:locatedAt -->
 
     <owl:ObjectProperty rdf:about="apartment:locatedAt">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Location"/>
-    </owl:ObjectProperty>   
+    </owl:ObjectProperty>
+    
 
 
-    <!--    apartment:nextTo   -->
+    <!-- apartment:locatedInRoom -->
+
+    <owl:ObjectProperty rdf:about="apartment:locatedInRoom">
+        <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
+        <rdfs:domain rdf:resource="apartment:Object"/>
+        <rdfs:range rdf:resource="apartment:Room"/>
+    </owl:ObjectProperty>
+    
+
+
+    <!-- apartment:nextTo -->
 
     <owl:ObjectProperty rdf:about="apartment:nextTo">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
@@ -130,7 +141,7 @@
     
 
 
-    <!--    apartment:onTopOf   -->
+    <!-- apartment:onTopOf -->
 
     <owl:ObjectProperty rdf:about="apartment:onTopOf">
         <rdfs:domain rdf:resource="apartment:Object"/>
@@ -139,7 +150,7 @@
     
 
 
-    <!--    apartment:oppositeTo   -->
+    <!-- apartment:oppositeTo -->
 
     <owl:ObjectProperty rdf:about="apartment:oppositeTo">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
@@ -149,7 +160,7 @@
     
 
 
-    <!--    apartment:toTheLeftOf   -->
+    <!-- apartment:toTheLeftOf -->
 
     <owl:ObjectProperty rdf:about="apartment:toTheLeftOf">
         <owl:inverseOf rdf:resource="apartment:toTheRightOf"/>
@@ -160,7 +171,7 @@
     
 
 
-    <!--    apartment:toTheRightOf   -->
+    <!-- apartment:toTheRightOf -->
 
     <owl:ObjectProperty rdf:about="apartment:toTheRightOf"/>
     
@@ -177,7 +188,23 @@
     
 
 
-    <!--    apartment:Appliance   -->
+    <!-- apartment:Alcohol -->
+
+    <owl:Class rdf:about="apartment:Alcohol">
+        <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Apple -->
+
+    <owl:Class rdf:about="apartment:Apple">
+        <rdfs:subClassOf rdf:resource="apartment:Fruit"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Appliance -->
 
     <owl:Class rdf:about="apartment:Appliance">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
@@ -185,7 +212,79 @@
     
 
 
-    <!--    apartment:Cabinet   -->
+    <!-- apartment:Banana -->
+
+    <owl:Class rdf:about="apartment:Banana">
+        <rdfs:subClassOf rdf:resource="apartment:Fruit"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Beef -->
+
+    <owl:Class rdf:about="apartment:Beef">
+        <rdfs:subClassOf rdf:resource="apartment:Meat"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Beer -->
+
+    <owl:Class rdf:about="apartment:Beer">
+        <rdfs:subClassOf rdf:resource="apartment:Alcohol"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Bowl -->
+
+    <owl:Class rdf:about="apartment:Bowl">
+        <rdfs:subClassOf rdf:resource="apartment:Dish"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Bread -->
+
+    <owl:Class rdf:about="apartment:Bread">
+        <rdfs:subClassOf rdf:resource="apartment:Grain"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:BreadKnife -->
+
+    <owl:Class rdf:about="apartment:BreadKnife">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Broccoli -->
+
+    <owl:Class rdf:about="apartment:Broccoli">
+        <rdfs:subClassOf rdf:resource="apartment:Vegetable"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Butter -->
+
+    <owl:Class rdf:about="apartment:Butter">
+        <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Buttermilk -->
+
+    <owl:Class rdf:about="apartment:Buttermilk">
+        <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Cabinet -->
 
     <owl:Class rdf:about="apartment:Cabinet">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
@@ -193,7 +292,15 @@
     
 
 
-    <!--    apartment:Chair   -->
+    <!-- apartment:Cereal -->
+
+    <owl:Class rdf:about="apartment:Cereal">
+        <rdfs:subClassOf rdf:resource="apartment:Grain"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Chair -->
 
     <owl:Class rdf:about="apartment:Chair">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
@@ -201,7 +308,23 @@
     
 
 
-    <!--    apartment:CoffeeTable   -->
+    <!-- apartment:Cheese -->
+
+    <owl:Class rdf:about="apartment:Cheese">
+        <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Chicken -->
+
+    <owl:Class rdf:about="apartment:Chicken">
+        <rdfs:subClassOf rdf:resource="apartment:Meat"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:CoffeeTable -->
 
     <owl:Class rdf:about="apartment:CoffeeTable">
         <rdfs:subClassOf rdf:resource="apartment:Table"/>
@@ -209,7 +332,15 @@
     
 
 
-    <!--    apartment:Computer   -->
+    <!-- apartment:Colander -->
+
+    <owl:Class rdf:about="apartment:Colander">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Computer -->
 
     <owl:Class rdf:about="apartment:Computer">
         <rdfs:subClassOf rdf:resource="apartment:Equipment"/>
@@ -217,7 +348,7 @@
     
 
 
-    <!--    apartment:Container   -->
+    <!-- apartment:Container -->
 
     <owl:Class rdf:about="apartment:Container">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
@@ -225,7 +356,15 @@
     
 
 
-    <!--    apartment:Couch   -->
+    <!-- apartment:Cookie -->
+
+    <owl:Class rdf:about="apartment:Cookie">
+        <rdfs:subClassOf rdf:resource="apartment:Snack"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Couch -->
 
     <owl:Class rdf:about="apartment:Couch">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
@@ -233,7 +372,7 @@
     
 
 
-    <!--    apartment:Counter   -->
+    <!-- apartment:Counter -->
 
     <owl:Class rdf:about="apartment:Counter">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
@@ -241,7 +380,47 @@
     
 
 
-    <!--    apartment:DiningRoom   -->
+    <!-- apartment:Cream -->
+
+    <owl:Class rdf:about="apartment:Cream">
+        <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Cup -->
+
+    <owl:Class rdf:about="apartment:Cup">
+        <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Cutlery -->
+
+    <owl:Class rdf:about="apartment:Cutlery">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:CuttingBoard -->
+
+    <owl:Class rdf:about="apartment:CuttingBoard">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Dairy -->
+
+    <owl:Class rdf:about="apartment:Dairy">
+        <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:DiningRoom -->
 
     <owl:Class rdf:about="apartment:DiningRoom">
         <rdfs:subClassOf rdf:resource="apartment:Room"/>
@@ -249,7 +428,7 @@
     
 
 
-    <!--    apartment:DiningTable   -->
+    <!-- apartment:DiningTable -->
 
     <owl:Class rdf:about="apartment:DiningTable">
         <rdfs:subClassOf rdf:resource="apartment:Table"/>
@@ -257,7 +436,7 @@
     
 
 
-    <!--    apartment:DiningTableChair   -->
+    <!-- apartment:DiningTableChair -->
 
     <owl:Class rdf:about="apartment:DiningTableChair">
         <rdfs:subClassOf rdf:resource="apartment:Chair"/>
@@ -265,7 +444,15 @@
     
 
 
-    <!--    apartment:Dishwasher   -->
+    <!-- apartment:Dish -->
+
+    <owl:Class rdf:about="apartment:Dish">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Dishwasher -->
 
     <owl:Class rdf:about="apartment:Dishwasher">
         <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
@@ -273,7 +460,15 @@
     
 
 
-    <!--    apartment:Drinkware   -->
+    <!-- apartment:Drawer -->
+
+    <owl:Class rdf:about="apartment:Drawer">
+        <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Drinkware -->
 
     <owl:Class rdf:about="apartment:Drinkware">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
@@ -281,169 +476,7 @@
     
 
 
-    <!--    apartment:Food   -->
-
-    <owl:Class rdf:about="apartment:Food">
-        <rdfs:subClassOf rdf:resource="apartment:Object"/>
-    </owl:Class>
-    
-
-
-    <!--    apartment:Fridge   -->
-
-    <owl:Class rdf:about="apartment:Fridge">
-        <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
-    </owl:Class>
-    
-
-
-    <!--    apartment:Furniture   -->
-
-    <owl:Class rdf:about="apartment:Furniture">
-        <rdfs:subClassOf rdf:resource="apartment:Object"/>
-    </owl:Class>
-    
-
-
-    <!--    apartment:Glass   -->
-
-    <owl:Class rdf:about="apartment:Glass">
-        <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
-    </owl:Class>
-    
-
-
-    <!--    apartment:Kitchen   -->
-
-    <owl:Class rdf:about="apartment:Kitchen">
-        <rdfs:subClassOf rdf:resource="apartment:Room"/>
-    </owl:Class>
-    
-
-
-    <!--    apartment:LivingRoom   -->
-
-    <owl:Class rdf:about="apartment:LivingRoom">
-        <rdfs:subClassOf rdf:resource="apartment:Room"/>
-    </owl:Class>
-    
-
-
-    <!--    apartment:Location   -->
-
-    <owl:Class rdf:about="apartment:Location"/>
-    
-
-
-    <!--    apartment:Mug   -->
-
-    <owl:Class rdf:about="apartment:Mug">
-        <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
-    </owl:Class>
-    
-
-
-    <!--    apartment:Object   -->
-
-    <owl:Class rdf:about="apartment:Object"/>
-    
-
-
-    <!--    apartment:Office   -->
-
-    <owl:Class rdf:about="apartment:Office">
-        <rdfs:subClassOf rdf:resource="apartment:Room"/>
-    </owl:Class>
-    
-
-
-    <!--    apartment:OfficeChair   -->
-
-    <owl:Class rdf:about="apartment:OfficeChair">
-        <rdfs:subClassOf rdf:resource="apartment:Chair"/>
-    </owl:Class>
-    
-
-
-    <!--    apartment:OfficeTable   -->
-
-    <owl:Class rdf:about="apartment:OfficeTable">
-        <rdfs:subClassOf rdf:resource="apartment:Table"/>
-    </owl:Class>
-    
-
-
-    <!--    apartment:Oven   -->
-
-    <owl:Class rdf:about="apartment:Oven">
-        <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
-    </owl:Class>
-    
-
-
-    <!--    apartment:Plane   -->
-
-    <owl:Class rdf:about="apartment:Plane"/>
-    
-
-
-    <!--    apartment:Robot   -->
-
-    <owl:Class rdf:about="apartment:Robot">
-        <rdfs:subClassOf rdf:resource="apartment:Equipment"/>
-    </owl:Class>
-    
-
-
-    <!--    apartment:Room   -->
-
-    <owl:Class rdf:about="apartment:Room">
-        <rdfs:subClassOf rdf:resource="apartment:Location"/>
-    </owl:Class>
-    
-
-
-    <!--    apartment:Shelf   -->
-
-    <owl:Class rdf:about="apartment:Shelf">
-        <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
-    </owl:Class>
-    
-
-
-    <!--    apartment:Sideboard   -->
-
-    <owl:Class rdf:about="apartment:Sideboard">
-        <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
-    </owl:Class>
-    
-
-
-    <!--    apartment:Snacks   -->
-
-    <owl:Class rdf:about="apartment:Snacks">
-        <rdfs:subClassOf rdf:resource="apartment:Food"/>
-    </owl:Class>
-    
-
-
-    <!--    apartment:Table   -->
-
-    <owl:Class rdf:about="apartment:Table">
-        <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
-    </owl:Class>
-    
-
-
-    <!--    apartment:Wall   -->
-
-    <owl:Class rdf:about="apartment:Wall">
-        <rdfs:subClassOf rdf:resource="apartment:Location"/>
-    </owl:Class>
-    
-
-
-    <!--  apartment:Equipment   -->
+    <!-- apartment:Equipment -->
 
     <owl:Class rdf:about="apartment:Equipment">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
@@ -451,10 +484,524 @@
     
 
 
-    <!--  apartment:Robot   -->
+    <!-- apartment:FoodOrDrink -->
+
+    <owl:Class rdf:about="apartment:FoodOrDrink">
+        <rdfs:subClassOf rdf:resource="apartment:Object"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Fork -->
+
+    <owl:Class rdf:about="apartment:Fork">
+        <rdfs:subClassOf rdf:resource="apartment:Cutlery"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Fridge -->
+
+    <owl:Class rdf:about="apartment:Fridge">
+        <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Fruit -->
+
+    <owl:Class rdf:about="apartment:Fruit">
+        <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Furniture -->
+
+    <owl:Class rdf:about="apartment:Furniture">
+        <rdfs:subClassOf rdf:resource="apartment:Object"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Glass -->
+
+    <owl:Class rdf:about="apartment:Glass">
+        <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Grain -->
+
+    <owl:Class rdf:about="apartment:Grain">
+        <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Grater -->
+
+    <owl:Class rdf:about="apartment:Grater">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Ham -->
+
+    <owl:Class rdf:about="apartment:Ham">
+        <rdfs:subClassOf rdf:resource="apartment:Meat"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:IceCream -->
+
+    <owl:Class rdf:about="apartment:IceCream">
+        <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Ketchup -->
+
+    <owl:Class rdf:about="apartment:Ketchup">
+        <rdfs:subClassOf rdf:resource="apartment:Sauce"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Kitchen -->
+
+    <owl:Class rdf:about="apartment:Kitchen">
+        <rdfs:subClassOf rdf:resource="apartment:Room"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:KitchenUtensil -->
+
+    <owl:Class rdf:about="apartment:KitchenUtensil">
+        <rdfs:subClassOf rdf:resource="apartment:Object"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Knife -->
+
+    <owl:Class rdf:about="apartment:Knife">
+        <rdfs:subClassOf rdf:resource="apartment:Cutlery"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Laptop -->
+
+    <owl:Class rdf:about="apartment:Laptop">
+        <rdfs:subClassOf rdf:resource="apartment:Equipment"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Lettuce -->
+
+    <owl:Class rdf:about="apartment:Lettuce">
+        <rdfs:subClassOf rdf:resource="apartment:Vegetable"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:LivingRoom -->
+
+    <owl:Class rdf:about="apartment:LivingRoom">
+        <rdfs:subClassOf rdf:resource="apartment:Room"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Location -->
+
+    <owl:Class rdf:about="apartment:Location"/>
+    
+
+
+    <!-- apartment:Mayo -->
+
+    <owl:Class rdf:about="apartment:Mayo">
+        <rdfs:subClassOf rdf:resource="apartment:Sauce"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Meat -->
+
+    <owl:Class rdf:about="apartment:Meat">
+        <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:MicrowaveOven -->
+
+    <owl:Class rdf:about="apartment:MicrowaveOven">
+        <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Milk -->
+
+    <owl:Class rdf:about="apartment:Milk">
+        <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Mixer -->
+
+    <owl:Class rdf:about="apartment:Mixer">
+        <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Mug -->
+
+    <owl:Class rdf:about="apartment:Mug">
+        <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Mustard -->
+
+    <owl:Class rdf:about="apartment:Mustard">
+        <rdfs:subClassOf rdf:resource="apartment:Sauce"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Object -->
+
+    <owl:Class rdf:about="apartment:Object"/>
+    
+
+
+    <!-- apartment:Office -->
+
+    <owl:Class rdf:about="apartment:Office">
+        <rdfs:subClassOf rdf:resource="apartment:Room"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:OfficeChair -->
+
+    <owl:Class rdf:about="apartment:OfficeChair">
+        <rdfs:subClassOf rdf:resource="apartment:Chair"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:OfficeTable -->
+
+    <owl:Class rdf:about="apartment:OfficeTable">
+        <rdfs:subClassOf rdf:resource="apartment:Table"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Onion -->
+
+    <owl:Class rdf:about="apartment:Onion">
+        <rdfs:subClassOf rdf:resource="apartment:Vegetable"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Orange -->
+
+    <owl:Class rdf:about="apartment:Orange">
+        <rdfs:subClassOf rdf:resource="apartment:Fruit"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Oven -->
+
+    <owl:Class rdf:about="apartment:Oven">
+        <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Pan -->
+
+    <owl:Class rdf:about="apartment:Pan">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Pasta -->
+
+    <owl:Class rdf:about="apartment:Pasta">
+        <rdfs:subClassOf rdf:resource="apartment:Grain"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Peanut -->
+
+    <owl:Class rdf:about="apartment:Peanut">
+        <rdfs:subClassOf rdf:resource="apartment:Snack"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Pear -->
+
+    <owl:Class rdf:about="apartment:Pear">
+        <rdfs:subClassOf rdf:resource="apartment:Fruit"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Plane -->
+
+    <owl:Class rdf:about="apartment:Plane"/>
+    
+
+
+    <!-- apartment:Plate -->
+
+    <owl:Class rdf:about="apartment:Plate">
+        <rdfs:subClassOf rdf:resource="apartment:Dish"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Popcorn -->
+
+    <owl:Class rdf:about="apartment:Popcorn">
+        <rdfs:subClassOf rdf:resource="apartment:Grain"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Pork -->
+
+    <owl:Class rdf:about="apartment:Pork">
+        <rdfs:subClassOf rdf:resource="apartment:Meat"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Pot -->
+
+    <owl:Class rdf:about="apartment:Pot">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:PotatoChips -->
+
+    <owl:Class rdf:about="apartment:PotatoChips">
+        <rdfs:subClassOf rdf:resource="apartment:Snack"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Rice -->
+
+    <owl:Class rdf:about="apartment:Rice">
+        <rdfs:subClassOf rdf:resource="apartment:Grain"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Robot -->
 
     <owl:Class rdf:about="apartment:Robot">
         <rdfs:subClassOf rdf:resource="apartment:Equipment"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:RollingPin -->
+
+    <owl:Class rdf:about="apartment:RollingPin">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Room -->
+
+    <owl:Class rdf:about="apartment:Room">
+        <rdfs:subClassOf rdf:resource="apartment:Location"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Sauce -->
+
+    <owl:Class rdf:about="apartment:Sauce">
+        <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Shelf -->
+
+    <owl:Class rdf:about="apartment:Shelf">
+        <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:ShotGlass -->
+
+    <owl:Class rdf:about="apartment:ShotGlass">
+        <rdfs:subClassOf rdf:resource="apartment:Glass"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Sideboard -->
+
+    <owl:Class rdf:about="apartment:Sideboard">
+        <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Snack -->
+
+    <owl:Class rdf:about="apartment:Snack">
+        <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Spatula -->
+
+    <owl:Class rdf:about="apartment:Spatula">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Spinach -->
+
+    <owl:Class rdf:about="apartment:Spinach">
+        <rdfs:subClassOf rdf:resource="apartment:Vegetable"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Spoon -->
+
+    <owl:Class rdf:about="apartment:Spoon">
+        <rdfs:subClassOf rdf:resource="apartment:Cutlery"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Stove -->
+
+    <owl:Class rdf:about="apartment:Stove">
+        <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Table -->
+
+    <owl:Class rdf:about="apartment:Table">
+        <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:VacuumCleaner -->
+
+    <owl:Class rdf:about="apartment:VacuumCleaner">
+        <rdfs:subClassOf rdf:resource="apartment:Equipment"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Vegetable -->
+
+    <owl:Class rdf:about="apartment:Vegetable">
+        <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Wall -->
+
+    <owl:Class rdf:about="apartment:Wall">
+        <rdfs:subClassOf rdf:resource="apartment:Location"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Water -->
+
+    <owl:Class rdf:about="apartment:Water">
+        <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:WaterBoiler -->
+
+    <owl:Class rdf:about="apartment:WaterBoiler">
+        <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Whisk -->
+
+    <owl:Class rdf:about="apartment:Whisk">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Wine -->
+
+    <owl:Class rdf:about="apartment:Wine">
+        <rdfs:subClassOf rdf:resource="apartment:Alcohol"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:WineGlass -->
+
+    <owl:Class rdf:about="apartment:WineGlass">
+        <rdfs:subClassOf rdf:resource="apartment:Glass"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:WoodenSpoon -->
+
+    <owl:Class rdf:about="apartment:WoodenSpoon">
+        <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
+    </owl:Class>
+    
+
+
+    <!-- apartment:Yogurt -->
+
+    <owl:Class rdf:about="apartment:Yogurt">
+        <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
     </owl:Class>
 </rdf:RDF>
 

--- a/common/ontology/homelab.owl
+++ b/common/ontology/homelab.owl
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<rdf:RDF xmlns="http://homelab#"
-     xml:base="http://homelab"
+<rdf:RDF xmlns="http://b-it-bots.de/ontologies/homelab#"
+     xml:base="http:/b-it-bots.de/ontologies/homelab"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"

--- a/common/ontology/homelab.owl
+++ b/common/ontology/homelab.owl
@@ -1,16 +1,15 @@
 <?xml version="1.0"?>
-<rdf:RDF xmlns="http://b-it-bots.de/ontologies/homelab#"
-     xml:base="http:/b-it-bots.de/ontologies/homelab"
+<rdf:RDF
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
     <owl:Ontology rdf:about="urn:absolute:homelab"/>
-    
 
 
-    <!-- 
+
+    <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Object Properties
@@ -18,7 +17,7 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    
+
 
 
     <!-- apartment:above -->
@@ -29,13 +28,13 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Object"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:below -->
 
     <owl:ObjectProperty rdf:about="apartment:below"/>
-    
+
 
 
     <!-- apartment:canPlaceOn -->
@@ -44,7 +43,7 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Plane"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:closeTo -->
@@ -54,7 +53,7 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Object"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:closeToWall -->
@@ -64,7 +63,7 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Wall"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:connectedTo -->
@@ -74,7 +73,7 @@
         <rdfs:domain rdf:resource="apartment:Room"/>
         <rdfs:range rdf:resource="apartment:Room"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:defaultLocation -->
@@ -84,7 +83,7 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Furniture"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:hasDoor -->
@@ -99,7 +98,7 @@
             </owl:Restriction>
         </rdfs:range>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:inside -->
@@ -108,7 +107,7 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Object"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:locatedAt -->
@@ -118,7 +117,7 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Location"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:locatedInRoom -->
@@ -128,7 +127,7 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Room"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:nextTo -->
@@ -138,7 +137,7 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Object"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:onTopOf -->
@@ -147,7 +146,7 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Object"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:oppositeTo -->
@@ -157,7 +156,7 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Object"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:toTheLeftOf -->
@@ -168,16 +167,16 @@
         <rdfs:domain rdf:resource="apartment:Object"/>
         <rdfs:range rdf:resource="apartment:Object"/>
     </owl:ObjectProperty>
-    
+
 
 
     <!-- apartment:toTheRightOf -->
 
     <owl:ObjectProperty rdf:about="apartment:toTheRightOf"/>
-    
 
 
-    <!-- 
+
+    <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Classes
@@ -185,7 +184,7 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    
+
 
 
     <!-- apartment:Alcohol -->
@@ -193,7 +192,7 @@
     <owl:Class rdf:about="apartment:Alcohol">
         <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Apple -->
@@ -201,7 +200,7 @@
     <owl:Class rdf:about="apartment:Apple">
         <rdfs:subClassOf rdf:resource="apartment:Fruit"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Appliance -->
@@ -209,7 +208,7 @@
     <owl:Class rdf:about="apartment:Appliance">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Banana -->
@@ -217,7 +216,7 @@
     <owl:Class rdf:about="apartment:Banana">
         <rdfs:subClassOf rdf:resource="apartment:Fruit"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Beef -->
@@ -225,7 +224,7 @@
     <owl:Class rdf:about="apartment:Beef">
         <rdfs:subClassOf rdf:resource="apartment:Meat"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Beer -->
@@ -233,7 +232,7 @@
     <owl:Class rdf:about="apartment:Beer">
         <rdfs:subClassOf rdf:resource="apartment:Alcohol"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Bowl -->
@@ -241,7 +240,7 @@
     <owl:Class rdf:about="apartment:Bowl">
         <rdfs:subClassOf rdf:resource="apartment:Dish"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Bread -->
@@ -249,7 +248,7 @@
     <owl:Class rdf:about="apartment:Bread">
         <rdfs:subClassOf rdf:resource="apartment:Grain"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:BreadKnife -->
@@ -257,7 +256,7 @@
     <owl:Class rdf:about="apartment:BreadKnife">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Broccoli -->
@@ -265,7 +264,7 @@
     <owl:Class rdf:about="apartment:Broccoli">
         <rdfs:subClassOf rdf:resource="apartment:Vegetable"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Butter -->
@@ -273,7 +272,7 @@
     <owl:Class rdf:about="apartment:Butter">
         <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Buttermilk -->
@@ -281,7 +280,7 @@
     <owl:Class rdf:about="apartment:Buttermilk">
         <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Cabinet -->
@@ -289,7 +288,7 @@
     <owl:Class rdf:about="apartment:Cabinet">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Cereal -->
@@ -297,7 +296,7 @@
     <owl:Class rdf:about="apartment:Cereal">
         <rdfs:subClassOf rdf:resource="apartment:Grain"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Chair -->
@@ -305,7 +304,7 @@
     <owl:Class rdf:about="apartment:Chair">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Cheese -->
@@ -313,7 +312,7 @@
     <owl:Class rdf:about="apartment:Cheese">
         <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Chicken -->
@@ -321,7 +320,7 @@
     <owl:Class rdf:about="apartment:Chicken">
         <rdfs:subClassOf rdf:resource="apartment:Meat"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:CoffeeTable -->
@@ -329,7 +328,7 @@
     <owl:Class rdf:about="apartment:CoffeeTable">
         <rdfs:subClassOf rdf:resource="apartment:Table"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Colander -->
@@ -337,7 +336,7 @@
     <owl:Class rdf:about="apartment:Colander">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Computer -->
@@ -345,7 +344,7 @@
     <owl:Class rdf:about="apartment:Computer">
         <rdfs:subClassOf rdf:resource="apartment:Equipment"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Container -->
@@ -353,7 +352,7 @@
     <owl:Class rdf:about="apartment:Container">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Cookie -->
@@ -361,7 +360,7 @@
     <owl:Class rdf:about="apartment:Cookie">
         <rdfs:subClassOf rdf:resource="apartment:Snack"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Couch -->
@@ -369,7 +368,7 @@
     <owl:Class rdf:about="apartment:Couch">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Counter -->
@@ -377,7 +376,7 @@
     <owl:Class rdf:about="apartment:Counter">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Cream -->
@@ -385,7 +384,7 @@
     <owl:Class rdf:about="apartment:Cream">
         <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Cup -->
@@ -393,7 +392,7 @@
     <owl:Class rdf:about="apartment:Cup">
         <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Cutlery -->
@@ -401,7 +400,7 @@
     <owl:Class rdf:about="apartment:Cutlery">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:CuttingBoard -->
@@ -409,7 +408,7 @@
     <owl:Class rdf:about="apartment:CuttingBoard">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Dairy -->
@@ -417,7 +416,7 @@
     <owl:Class rdf:about="apartment:Dairy">
         <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:DiningRoom -->
@@ -425,7 +424,7 @@
     <owl:Class rdf:about="apartment:DiningRoom">
         <rdfs:subClassOf rdf:resource="apartment:Room"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:DiningTable -->
@@ -433,7 +432,7 @@
     <owl:Class rdf:about="apartment:DiningTable">
         <rdfs:subClassOf rdf:resource="apartment:Table"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:DiningTableChair -->
@@ -441,7 +440,7 @@
     <owl:Class rdf:about="apartment:DiningTableChair">
         <rdfs:subClassOf rdf:resource="apartment:Chair"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Dish -->
@@ -449,7 +448,7 @@
     <owl:Class rdf:about="apartment:Dish">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Dishwasher -->
@@ -457,7 +456,7 @@
     <owl:Class rdf:about="apartment:Dishwasher">
         <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Drawer -->
@@ -465,7 +464,7 @@
     <owl:Class rdf:about="apartment:Drawer">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Drinkware -->
@@ -473,7 +472,7 @@
     <owl:Class rdf:about="apartment:Drinkware">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Equipment -->
@@ -481,7 +480,7 @@
     <owl:Class rdf:about="apartment:Equipment">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:FoodOrDrink -->
@@ -489,7 +488,7 @@
     <owl:Class rdf:about="apartment:FoodOrDrink">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Fork -->
@@ -497,7 +496,7 @@
     <owl:Class rdf:about="apartment:Fork">
         <rdfs:subClassOf rdf:resource="apartment:Cutlery"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Fridge -->
@@ -505,7 +504,7 @@
     <owl:Class rdf:about="apartment:Fridge">
         <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Fruit -->
@@ -513,7 +512,7 @@
     <owl:Class rdf:about="apartment:Fruit">
         <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Furniture -->
@@ -521,7 +520,7 @@
     <owl:Class rdf:about="apartment:Furniture">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Glass -->
@@ -529,7 +528,7 @@
     <owl:Class rdf:about="apartment:Glass">
         <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Grain -->
@@ -537,7 +536,7 @@
     <owl:Class rdf:about="apartment:Grain">
         <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Grater -->
@@ -545,7 +544,7 @@
     <owl:Class rdf:about="apartment:Grater">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Ham -->
@@ -553,7 +552,7 @@
     <owl:Class rdf:about="apartment:Ham">
         <rdfs:subClassOf rdf:resource="apartment:Meat"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:IceCream -->
@@ -561,7 +560,7 @@
     <owl:Class rdf:about="apartment:IceCream">
         <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Ketchup -->
@@ -569,7 +568,7 @@
     <owl:Class rdf:about="apartment:Ketchup">
         <rdfs:subClassOf rdf:resource="apartment:Sauce"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Kitchen -->
@@ -577,7 +576,7 @@
     <owl:Class rdf:about="apartment:Kitchen">
         <rdfs:subClassOf rdf:resource="apartment:Room"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:KitchenUtensil -->
@@ -585,7 +584,7 @@
     <owl:Class rdf:about="apartment:KitchenUtensil">
         <rdfs:subClassOf rdf:resource="apartment:Object"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Knife -->
@@ -593,7 +592,7 @@
     <owl:Class rdf:about="apartment:Knife">
         <rdfs:subClassOf rdf:resource="apartment:Cutlery"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Laptop -->
@@ -601,7 +600,7 @@
     <owl:Class rdf:about="apartment:Laptop">
         <rdfs:subClassOf rdf:resource="apartment:Equipment"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Lettuce -->
@@ -609,7 +608,7 @@
     <owl:Class rdf:about="apartment:Lettuce">
         <rdfs:subClassOf rdf:resource="apartment:Vegetable"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:LivingRoom -->
@@ -617,13 +616,13 @@
     <owl:Class rdf:about="apartment:LivingRoom">
         <rdfs:subClassOf rdf:resource="apartment:Room"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Location -->
 
     <owl:Class rdf:about="apartment:Location"/>
-    
+
 
 
     <!-- apartment:Mayo -->
@@ -631,7 +630,7 @@
     <owl:Class rdf:about="apartment:Mayo">
         <rdfs:subClassOf rdf:resource="apartment:Sauce"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Meat -->
@@ -639,7 +638,7 @@
     <owl:Class rdf:about="apartment:Meat">
         <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:MicrowaveOven -->
@@ -647,7 +646,7 @@
     <owl:Class rdf:about="apartment:MicrowaveOven">
         <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Milk -->
@@ -655,7 +654,7 @@
     <owl:Class rdf:about="apartment:Milk">
         <rdfs:subClassOf rdf:resource="apartment:Dairy"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Mixer -->
@@ -663,7 +662,7 @@
     <owl:Class rdf:about="apartment:Mixer">
         <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Mug -->
@@ -671,7 +670,7 @@
     <owl:Class rdf:about="apartment:Mug">
         <rdfs:subClassOf rdf:resource="apartment:Drinkware"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Mustard -->
@@ -679,13 +678,13 @@
     <owl:Class rdf:about="apartment:Mustard">
         <rdfs:subClassOf rdf:resource="apartment:Sauce"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Object -->
 
     <owl:Class rdf:about="apartment:Object"/>
-    
+
 
 
     <!-- apartment:Office -->
@@ -693,7 +692,7 @@
     <owl:Class rdf:about="apartment:Office">
         <rdfs:subClassOf rdf:resource="apartment:Room"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:OfficeChair -->
@@ -701,7 +700,7 @@
     <owl:Class rdf:about="apartment:OfficeChair">
         <rdfs:subClassOf rdf:resource="apartment:Chair"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:OfficeTable -->
@@ -709,7 +708,7 @@
     <owl:Class rdf:about="apartment:OfficeTable">
         <rdfs:subClassOf rdf:resource="apartment:Table"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Onion -->
@@ -717,7 +716,7 @@
     <owl:Class rdf:about="apartment:Onion">
         <rdfs:subClassOf rdf:resource="apartment:Vegetable"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Orange -->
@@ -725,7 +724,7 @@
     <owl:Class rdf:about="apartment:Orange">
         <rdfs:subClassOf rdf:resource="apartment:Fruit"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Oven -->
@@ -733,7 +732,7 @@
     <owl:Class rdf:about="apartment:Oven">
         <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Pan -->
@@ -741,7 +740,7 @@
     <owl:Class rdf:about="apartment:Pan">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Pasta -->
@@ -749,7 +748,7 @@
     <owl:Class rdf:about="apartment:Pasta">
         <rdfs:subClassOf rdf:resource="apartment:Grain"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Peanut -->
@@ -757,7 +756,7 @@
     <owl:Class rdf:about="apartment:Peanut">
         <rdfs:subClassOf rdf:resource="apartment:Snack"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Pear -->
@@ -765,13 +764,13 @@
     <owl:Class rdf:about="apartment:Pear">
         <rdfs:subClassOf rdf:resource="apartment:Fruit"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Plane -->
 
     <owl:Class rdf:about="apartment:Plane"/>
-    
+
 
 
     <!-- apartment:Plate -->
@@ -779,7 +778,7 @@
     <owl:Class rdf:about="apartment:Plate">
         <rdfs:subClassOf rdf:resource="apartment:Dish"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Popcorn -->
@@ -787,7 +786,7 @@
     <owl:Class rdf:about="apartment:Popcorn">
         <rdfs:subClassOf rdf:resource="apartment:Grain"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Pork -->
@@ -795,7 +794,7 @@
     <owl:Class rdf:about="apartment:Pork">
         <rdfs:subClassOf rdf:resource="apartment:Meat"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Pot -->
@@ -803,7 +802,7 @@
     <owl:Class rdf:about="apartment:Pot">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:PotatoChips -->
@@ -811,7 +810,7 @@
     <owl:Class rdf:about="apartment:PotatoChips">
         <rdfs:subClassOf rdf:resource="apartment:Snack"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Rice -->
@@ -819,7 +818,7 @@
     <owl:Class rdf:about="apartment:Rice">
         <rdfs:subClassOf rdf:resource="apartment:Grain"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Robot -->
@@ -827,7 +826,7 @@
     <owl:Class rdf:about="apartment:Robot">
         <rdfs:subClassOf rdf:resource="apartment:Equipment"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:RollingPin -->
@@ -835,7 +834,7 @@
     <owl:Class rdf:about="apartment:RollingPin">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Room -->
@@ -843,7 +842,7 @@
     <owl:Class rdf:about="apartment:Room">
         <rdfs:subClassOf rdf:resource="apartment:Location"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Sauce -->
@@ -851,7 +850,7 @@
     <owl:Class rdf:about="apartment:Sauce">
         <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Shelf -->
@@ -859,7 +858,7 @@
     <owl:Class rdf:about="apartment:Shelf">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:ShotGlass -->
@@ -867,7 +866,7 @@
     <owl:Class rdf:about="apartment:ShotGlass">
         <rdfs:subClassOf rdf:resource="apartment:Glass"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Sideboard -->
@@ -875,7 +874,7 @@
     <owl:Class rdf:about="apartment:Sideboard">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Snack -->
@@ -883,7 +882,7 @@
     <owl:Class rdf:about="apartment:Snack">
         <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Spatula -->
@@ -891,7 +890,7 @@
     <owl:Class rdf:about="apartment:Spatula">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Spinach -->
@@ -899,7 +898,7 @@
     <owl:Class rdf:about="apartment:Spinach">
         <rdfs:subClassOf rdf:resource="apartment:Vegetable"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Spoon -->
@@ -907,7 +906,7 @@
     <owl:Class rdf:about="apartment:Spoon">
         <rdfs:subClassOf rdf:resource="apartment:Cutlery"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Stove -->
@@ -915,7 +914,7 @@
     <owl:Class rdf:about="apartment:Stove">
         <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Table -->
@@ -923,7 +922,7 @@
     <owl:Class rdf:about="apartment:Table">
         <rdfs:subClassOf rdf:resource="apartment:Furniture"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:VacuumCleaner -->
@@ -931,7 +930,7 @@
     <owl:Class rdf:about="apartment:VacuumCleaner">
         <rdfs:subClassOf rdf:resource="apartment:Equipment"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Vegetable -->
@@ -939,7 +938,7 @@
     <owl:Class rdf:about="apartment:Vegetable">
         <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Wall -->
@@ -947,7 +946,7 @@
     <owl:Class rdf:about="apartment:Wall">
         <rdfs:subClassOf rdf:resource="apartment:Location"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Water -->
@@ -955,7 +954,7 @@
     <owl:Class rdf:about="apartment:Water">
         <rdfs:subClassOf rdf:resource="apartment:FoodOrDrink"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:WaterBoiler -->
@@ -963,7 +962,7 @@
     <owl:Class rdf:about="apartment:WaterBoiler">
         <rdfs:subClassOf rdf:resource="apartment:Appliance"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Whisk -->
@@ -971,7 +970,7 @@
     <owl:Class rdf:about="apartment:Whisk">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Wine -->
@@ -979,7 +978,7 @@
     <owl:Class rdf:about="apartment:Wine">
         <rdfs:subClassOf rdf:resource="apartment:Alcohol"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:WineGlass -->
@@ -987,7 +986,7 @@
     <owl:Class rdf:about="apartment:WineGlass">
         <rdfs:subClassOf rdf:resource="apartment:Glass"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:WoodenSpoon -->
@@ -995,7 +994,7 @@
     <owl:Class rdf:about="apartment:WoodenSpoon">
         <rdfs:subClassOf rdf:resource="apartment:KitchenUtensil"/>
     </owl:Class>
-    
+
 
 
     <!-- apartment:Yogurt -->
@@ -1008,4 +1007,3 @@
 
 
 <!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
-

--- a/common/tests/ontology_query_interface_unit_tests.py
+++ b/common/tests/ontology_query_interface_unit_tests.py
@@ -25,7 +25,7 @@ class ontology_query_interface_test(unittest.TestCase):
                                              class_prefix=self.ontology_ns)
 
     def test_get_classes(self):
-        validation_data = ['Drinkware', 'Furniture', 'Location', 'Mug', 
+        validation_data = ['Drinkware', 'Furniture', 'Location', 'Mug',
                            'Object', 'Room', 'Table', 'WorkTable']
         acquired_data = sorted(self.ont_if.get_classes())
         self.assertEqual(acquired_data, validation_data)
@@ -44,6 +44,14 @@ class ontology_query_interface_test(unittest.TestCase):
         self.assertTrue(self.ont_if.is_instance_of("CoffeeMug", "Mug"))
         self.assertFalse(self.ont_if.is_instance_of("Desk", "Mug"))
 
+    def test_is_subclass_of(self):
+        self.assertTrue(self.ont_if.is_subclass_of("Room", "Location"))
+        self.assertFalse(self.ont_if.is_subclass_of("Room", "Object"))
+
+    def test_is_parent_class_of(self):
+        self.assertTrue(self.ont_if.is_parent_class_of("Location", "Room"))
+        self.assertFalse(self.ont_if.is_parent_class_of("Object", "Room"))
+
     def test_get_class_hierarchy(self):
         validation_data = {'Drinkware': ['Mug'], 'Mug': [], 'WorkTable': [],
                            'Table': ['WorkTable'], 'Location': ['Room'],
@@ -55,7 +63,7 @@ class ontology_query_interface_test(unittest.TestCase):
                          sorted(list(validation_data.keys())))
 
         for class_name in acquired_data.keys():
-            self.assertEqual(sorted(acquired_data[class_name]), 
+            self.assertEqual(sorted(acquired_data[class_name]),
                              validation_data[class_name])
 
     def test_get_instances_of(self):
@@ -201,7 +209,7 @@ class ontology_query_interface_test(unittest.TestCase):
         self.assertTrue(self.ont_if.is_property(prop_2_name))
 
         # Validate the domain-range of the properties
-        self.assertEqual(("Object", "Location"), 
+        self.assertEqual(("Object", "Location"),
                          self.ont_if.get_property_domain_range(prop_1_name))
         self.assertEqual(("Object", "float"),
                          self.ont_if.get_property_domain_range(prop_2_name))

--- a/ros/scripts/export_ontology_to_kb
+++ b/ros/scripts/export_ontology_to_kb
@@ -61,13 +61,10 @@ class OntologyExporter(object):
                         fact = [obj_property, [(prop_domain + '0', subj),
                                                (prop_range + '1', obj)]]
 
-                    subj_instance = (prop_domain, subj)
-                    obj_instance = (prop_range, obj)
-
-                    if subj_instance not in instances_to_add:
-                        instances_to_add.append(subj_instance)
-                    if obj_instance not in instances_to_add:
-                        instances_to_add.append(obj_instance)
+                    instances_to_add = self.update_instance_in_list(subj, prop_domain,
+                                                                    instances_to_add)
+                    instances_to_add = self.update_instance_in_list(obj, prop_range,
+                                                                    instances_to_add)
 
                 facts_to_add.append(fact)
 
@@ -78,6 +75,43 @@ class OntologyExporter(object):
         self.kb_interface.insert_facts(facts_to_add)
 
         print('Ontology export complete')
+
+    def update_instance_in_list(self, instance, instance_type, instance_list):
+        '''Inserts or updates "instance" in "instance_list". In particular:
+        * returns "instance_list" if an entry (instance_type, instance) already exists
+        * returns an updated "instance_list" otherwise:
+            * if "instance" already exists in an entry in "instance_list", but the types
+              are different, takes the more specific type as the type of "instance" if
+              the types are in a ancestor/descendant relation. If the types are disjoint,
+              keeps the already existing type of "instance"
+            * if "instance" does not exist in any entry, a new entry
+            (instance_list, instance) is added to "instance_list"
+
+        Keyword arguments:
+        @param instance: str -- name of an instance in the ontology
+        @param instance_type: str -- type of "instance"
+        @param instance_list: Sequence[Tuple[str, str]] -- list of (type, instance) tuples
+
+        '''
+        if (instance_type, instance) in instance_list:
+            return instance_list
+
+        instance_inserted = False
+        for i, (inst_type, inst) in enumerate(instance_list):
+            if inst == instance:
+                if self.ont_query_interface.is_subclass_of(instance_type, inst_type):
+                    instance_list[i] = (instance_type, inst)
+                    instance_inserted = True
+                elif self.ont_query_interface.is_subclass_of(inst_type, instance_type):
+                    instance_list[i] = (inst_type, inst)
+                    instance_inserted = True
+                else:
+                    print('WARNING: {0} exists as an instance of two unrelated classes {1} and {2}'.format(inst, instance_type, inst_type))
+                    print('WARNING: Only exporting type {0}'.format(inst_type))
+
+        if not instance_inserted:
+            instance_list.append((instance_type, instance))
+        return instance_list
 
 if __name__ == '__main__':
     rospy.init_node('ontology_exporter')

--- a/ros/scripts/export_ontology_to_kb
+++ b/ros/scripts/export_ontology_to_kb
@@ -40,6 +40,7 @@ class OntologyExporter(object):
         '''
         object_properties = self.ont_query_interface.get_object_properties()
         facts_to_add = []
+        instances_to_add = []
         for obj_property in object_properties:
             (prop_domain, prop_range) = self.ont_query_interface.get_property_domain_range(obj_property)
             subj_obj_pairs = self.ont_query_interface.get_all_subjects_and_objects(obj_property)
@@ -59,8 +60,24 @@ class OntologyExporter(object):
                     else:
                         fact = [obj_property, [(prop_domain + '0', subj),
                                                (prop_range + '1', obj)]]
+
+                    subj_instance = (prop_domain, subj)
+                    obj_instance = (prop_range, obj)
+
+                    if subj_instance not in instances_to_add:
+                        instances_to_add.append(subj_instance)
+                    if obj_instance not in instances_to_add:
+                        instances_to_add.append(obj_instance)
+
                 facts_to_add.append(fact)
+
+        print('Inserting instances')
+        self.kb_interface.insert_instances(instances_to_add)
+
+        print('Inserting facts')
         self.kb_interface.insert_facts(facts_to_add)
+
+        print('Ontology export complete')
 
 if __name__ == '__main__':
     rospy.init_node('ontology_exporter')

--- a/ros/src/mas_knowledge_base/domestic_kb_interface.py
+++ b/ros/src/mas_knowledge_base/domestic_kb_interface.py
@@ -210,7 +210,7 @@ class DomesticKBInterface(KnowledgeBaseInterface):
             for param in item.values:
                 if param.key == 'obj':
                     obj_name = param.value
-                elif param.key == 'cat':
+                elif param.key == 'class':
                     obj_category = param.value
             obj_category_dict[obj_name] = obj_category
         return obj_category_dict

--- a/ros/src/mas_knowledge_base/domestic_kb_interface.py
+++ b/ros/src/mas_knowledge_base/domestic_kb_interface.py
@@ -359,8 +359,11 @@ class DomesticKBInterface(KnowledgeBaseInterface):
 
         '''
         known_people = self.get_all_objects(person_type, permanent_storage=True)
-        unknown_person = self.get_obj_instance(person_to_recognise_name, person_type)
+        if not known_people:
+            print('[recognise_person] No people found in the knowledge base')
+            return None
 
+        unknown_person = self.get_obj_instance(person_to_recognise_name, person_type)
         unknown_person_embedding = np.array(unknown_person.face.views[0].embedding.embedding)
         embedding_distances = np.zeros(len(known_people))
         for i, known_person in enumerate(known_people):

--- a/ros/src/mas_knowledge_base/domestic_kb_interface.py
+++ b/ros/src/mas_knowledge_base/domestic_kb_interface.py
@@ -364,6 +364,10 @@ class DomesticKBInterface(KnowledgeBaseInterface):
             return None
 
         unknown_person = self.get_obj_instance(person_to_recognise_name, person_type)
+        if not unknown_person.face.views[0].embedding.embedding:
+            print('[recognise_person] Could not recognise person; face not seen')
+            return None
+
         unknown_person_embedding = np.array(unknown_person.face.views[0].embedding.embedding)
         embedding_distances = np.zeros(len(known_people))
         for i, known_person in enumerate(known_people):

--- a/ros/src/mas_knowledge_base/domestic_kb_interface.py
+++ b/ros/src/mas_knowledge_base/domestic_kb_interface.py
@@ -364,9 +364,9 @@ class DomesticKBInterface(KnowledgeBaseInterface):
         unknown_person_embedding = np.array(unknown_person.face.views[0].embedding.embedding)
         embedding_distances = np.zeros(len(known_people))
         for i, known_person in enumerate(known_people):
-            distance = np.linalg.norm(np.array(known_person.face.views[0].embedding.embedding) - \
-                                      unknown_person_embedding)
-            embedding_distances[i] = distance
+            person_distances = [np.linalg.norm(np.array(view.embedding.embedding) - unknown_person_embedding)
+                                for view in known_person.face.views]
+            embedding_distances[i] = np.mean(person_distances)
         min_distance_idx = np.argmin(embedding_distances)
         if embedding_distances[min_distance_idx] < recognition_threshold:
             return known_people[min_distance_idx]

--- a/ros/src/mas_knowledge_base/knowledge_base_interface.py
+++ b/ros/src/mas_knowledge_base/knowledge_base_interface.py
@@ -120,6 +120,48 @@ class KnowledgeBaseInterface(object):
         rospy.loginfo('[kb_interface] Removing facts from the knowledge base')
         self.remove_facts(facts_to_remove)
 
+    def insert_instances(self, instances):
+        '''Inserts the given instances into the knowledge base.
+
+        Keyword arguments:
+        @param instances: Sequence[(str, str)] -- instances to be inserted; each instance
+                                                  is represented as a tuple of the format
+                                                  (instance_type, instance_name)
+
+        '''
+        try:
+            for (instance_type, instance_name) in instances:
+                request = rosplan_srvs.KnowledgeUpdateServiceRequest()
+                request.update_type = KnowledgeUpdateTypes.INSERT
+                request.knowledge.knowledge_type = 0
+                request.knowledge.instance_type = instance_type
+                request.knowledge.instance_name = instance_name
+                self.knowledge_update_client(request)
+        except Exception as exc:
+            rospy.logerr('[kb_interface] %s', str(exc))
+            raise KBException('Instances could not be inserted into the knowledge base')
+
+    def remove_instances(self, instances):
+        '''Removes the given instances from the knowledge base.
+
+        Keyword arguments:
+        @param instances: Sequence[(str, str)] -- instances to be removed; each instance
+                                                  is represented as a tuple of the format
+                                                  (instance_type, instance_name)
+
+        '''
+        try:
+            for (instance_type, instance_name) in instances:
+                request = rosplan_srvs.KnowledgeUpdateServiceRequest()
+                request.update_type = KnowledgeUpdateTypes.REMOVE
+                request.knowledge.knowledge_type = 0
+                request.knowledge.instance_type = instance_type
+                request.knowledge.instance_name = instance_name
+                self.knowledge_update_client(request)
+        except Exception as exc:
+            rospy.logerr('[kb_interface] %s', str(exc))
+            raise KBException('Instances could not be removed from the knowledge base')
+
     def insert_facts(self, fact_list):
         '''Inserts the facts in the given list into the knowledge base.
 

--- a/ros/src/mas_knowledge_base/knowledge_base_interface.py
+++ b/ros/src/mas_knowledge_base/knowledge_base_interface.py
@@ -263,6 +263,20 @@ class KnowledgeBaseInterface(object):
         '''
         self.msg_store_client.delete_named(obj_name, obj_type)
 
+    def get_all_objects(self, obj_type):
+        '''Returns a list of all objects of the given type:
+
+        Keyword arguments:
+        @param obj_type: str -- type of the objects to be retrieved
+
+        '''
+        try:
+            objects, _ = self.msg_store_client.query(obj_type)
+            return objects
+        except:
+            rospy.logerr('[kb_interface] Error retrieving knowledge about objects of type %s', obj_type)
+            return []
+
     def get_objects(self, object_names, obj_type):
         '''Returns a list of named object instances from the knowledge base.
 

--- a/test.py
+++ b/test.py
@@ -1,0 +1,3 @@
+from mas_tools.ros_utils import get_package_path
+from mas_knowledge_utils.domestic_ontology_interface import DomesticOntologyInterface
+from mas_knowledge_base.domestic_kb_interface import DomesticKBInterface

--- a/test.py
+++ b/test.py
@@ -1,3 +1,0 @@
-from mas_tools.ros_utils import get_package_path
-from mas_knowledge_utils.domestic_ontology_interface import DomesticOntologyInterface
-from mas_knowledge_base.domestic_kb_interface import DomesticKBInterface


### PR DESCRIPTION
This PR introduces various improvements and bug fixes to the ontology, ontology query interface, and the knowledge base interface:
* Various extensions and fixes to the `apartment` ontology (https://github.com/b-it-bots/mas_knowledge_base/pull/11, https://github.com/b-it-bots/mas_knowledge_base/pull/33) and the introduction of an ontology for C069 (https://github.com/b-it-bots/mas_knowledge_base/pull/13)
* Utilities for simplified population of the ontology from configuration files (https://github.com/b-it-bots/mas_knowledge_base/pull/17, https://github.com/b-it-bots/mas_knowledge_base/pull/28)
* Improvements to the ontology query interface (https://github.com/b-it-bots/mas_knowledge_base/pull/21, https://github.com/b-it-bots/mas_knowledge_base/pull/23, https://github.com/b-it-bots/mas_knowledge_base/pull/29) and the KB query interface (https://github.com/b-it-bots/mas_knowledge_base/pull/31, https://github.com/b-it-bots/mas_knowledge_base/pull/32, https://github.com/b-it-bots/mas_knowledge_base/pull/39)
* A functionality for exporting the knowledge stored in the ontology to a planning knowledge base (https://github.com/b-it-bots/mas_knowledge_base/pull/16, https://github.com/b-it-bots/mas_knowledge_base/pull/34)
* The possibility of storing things (e.g. object messages) in a permanent knowledge base (https://github.com/b-it-bots/mas_knowledge_base/pull/38)
* Unit tests for the ontology query interface (https://github.com/b-it-bots/mas_knowledge_base/pull/22, https://github.com/b-it-bots/mas_knowledge_base/pull/26)
* Examples for using the ontology query interface (https://github.com/b-it-bots/mas_knowledge_base/pull/25)