### PR TITLE
Support for ontology base URLs in the ontology query interface

### DIFF
--- a/common/mas_knowledge_utils/domestic_ontology_interface.py
+++ b/common/mas_knowledge_utils/domestic_ontology_interface.py
@@ -13,8 +13,11 @@ class DomesticOntologyInterface(OntologyQueryInterface):
     @contact aleksandar.mitrevski@h-brs.de
 
     '''
-    def __init__(self, ontology_file, class_prefix):
-        super(DomesticOntologyInterface, self).__init__(ontology_file, class_prefix)
+    def __init__(self, ontology_file, base_url=None, entity_delimiter='/', class_prefix=''):
+        super(DomesticOntologyInterface, self).__init__(ontology_file=ontology_file,
+                                                        base_url=base_url,
+                                                        entity_delimiter=entity_delimiter,
+                                                        class_prefix=class_prefix)
 
     def get_default_storing_location(self, obj_name=None, obj_category=None):
         '''Returns a string representing the default storing location of an

--- a/common/ontology/apartment.owl
+++ b/common/ontology/apartment.owl
@@ -1,17 +1,27 @@
 <?xml version="1.0"?>
-<rdf:RDF xmlns="http://apartment"
-     xml:base="http://apartment"
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY owl2xml "http://www.w3.org/2006/12/owl2-xml#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+    <!ENTITY apartment "http://apartment.owl#" >
+]>
+
+<rdf:RDF xmlns="http://apartment.owl#"
+     xml:base="http://apartment.owl"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:apartment="http://apartment#">
-    <owl:Ontology rdf:about="http://apartment"/>
-    
+     xmlns:apartment="http://apartment.owl#">
+    <owl:Ontology rdf:about="http://apartment.owl"/>
 
 
-    <!-- 
+
+    <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Object Properties
@@ -19,301 +29,301 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    
 
 
-    <!-- http://apartment#above -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#above">
-        <owl:inverseOf rdf:resource="http://apartment#below"/>
+    <!-- http://apartment.owl#above -->
+
+    <owl:ObjectProperty rdf:about="&apartment;above">
+        <owl:inverseOf rdf:resource="&apartment;below"/>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Object"/>
+        <rdfs:domain rdf:resource="&apartment;Object"/>
+        <rdfs:range rdf:resource="&apartment;Object"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#below -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#below">
+    <!-- http://apartment.owl#below -->
+
+    <owl:ObjectProperty rdf:about="&apartment;below">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#canPlaceOn -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#canPlaceOn">
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Plane"/>
+    <!-- http://apartment.owl#canPlaceOn -->
+
+    <owl:ObjectProperty rdf:about="&apartment;canPlaceOn">
+        <rdfs:domain rdf:resource="&apartment;Object"/>
+        <rdfs:range rdf:resource="&apartment;Plane"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#closeTo -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#closeTo">
+    <!-- http://apartment.owl#closeTo -->
+
+    <owl:ObjectProperty rdf:about="&apartment;closeTo">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Object"/>
+        <rdfs:domain rdf:resource="&apartment;Object"/>
+        <rdfs:range rdf:resource="&apartment;Object"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#closeToWall -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#closeToWall">
+    <!-- http://apartment.owl#closeToWall -->
+
+    <owl:ObjectProperty rdf:about="&apartment;closeToWall">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Wall"/>
+        <rdfs:domain rdf:resource="&apartment;Object"/>
+        <rdfs:range rdf:resource="&apartment;Wall"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#connectedTo -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#connectedTo">
+    <!-- http://apartment.owl#connectedTo -->
+
+    <owl:ObjectProperty rdf:about="&apartment;connectedTo">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Room"/>
-        <rdfs:range rdf:resource="http://apartment#Room"/>
+        <rdfs:domain rdf:resource="&apartment;Room"/>
+        <rdfs:range rdf:resource="&apartment;Room"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#defaultLocation -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#defaultLocation">
+    <!-- http://apartment.owl#defaultLocation -->
+
+    <owl:ObjectProperty rdf:about="&apartment;defaultLocation">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Furniture"/>
+        <rdfs:domain rdf:resource="&apartment;Object"/>
+        <rdfs:range rdf:resource="&apartment;Furniture"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#defaultStoringLocation -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#defaultStoringLocation">
+    <!-- http://apartment.owl#defaultStoringLocation -->
+
+    <owl:ObjectProperty rdf:about="&apartment;defaultStoringLocation">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Furniture"/>
+        <rdfs:domain rdf:resource="&apartment;Object"/>
+        <rdfs:range rdf:resource="&apartment;Furniture"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#hasDoor -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#hasDoor">
+    <!-- http://apartment.owl#hasDoor -->
+
+    <owl:ObjectProperty rdf:about="&apartment;hasDoor">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Furniture"/>
+        <rdfs:domain rdf:resource="&apartment;Furniture"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#hasPart -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#hasPart">
-        <owl:inverseOf rdf:resource="http://apartment#hasPart"/>
+    <!-- http://apartment.owl#hasPart -->
+
+    <owl:ObjectProperty rdf:about="&apartment;hasPart">
+        <owl:inverseOf rdf:resource="&apartment;hasPart"/>
         <rdfs:comment>This property is used to link objects to their sub-objects such as a cabinet has sub-object drawer.</rdfs:comment>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#inside -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#inside">
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Object"/>
+    <!-- http://apartment.owl#inside -->
+
+    <owl:ObjectProperty rdf:about="&apartment;inside">
+        <rdfs:domain rdf:resource="&apartment;Object"/>
+        <rdfs:range rdf:resource="&apartment;Object"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#isAtLocation -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#isAtLocation">
-        <rdfs:domain rdf:resource="http://apartment#NamedPose"/>
-        <rdfs:range rdf:resource="http://apartment#Location"/>
+    <!-- http://apartment.owl#isAtLocation -->
+
+    <owl:ObjectProperty rdf:about="&apartment;isAtLocation">
+        <rdfs:domain rdf:resource="&apartment;NamedPose"/>
+        <rdfs:range rdf:resource="&apartment;Location"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#isAtNamedPose -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#isAtNamedPose">
-        <rdfs:range rdf:resource="http://apartment#NamedPose"/>
+    <!-- http://apartment.owl#isAtNamedPose -->
+
+    <owl:ObjectProperty rdf:about="&apartment;isAtNamedPose">
+        <rdfs:range rdf:resource="&apartment;NamedPose"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#isPartOf -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#isPartOf"/>
-    
+    <!-- http://apartment.owl#isPartOf -->
+
+    <owl:ObjectProperty rdf:about="&apartment;isPartOf"/>
 
 
-    <!-- http://apartment#likelyLocation -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#likelyLocation">
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Furniture"/>
+    <!-- http://apartment.owl#likelyLocation -->
+
+    <owl:ObjectProperty rdf:about="&apartment;likelyLocation">
+        <rdfs:domain rdf:resource="&apartment;Object"/>
+        <rdfs:range rdf:resource="&apartment;Furniture"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#locatedAt -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#locatedAt">
+    <!-- http://apartment.owl#locatedAt -->
+
+    <owl:ObjectProperty rdf:about="&apartment;locatedAt">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Location"/>
+        <rdfs:domain rdf:resource="&apartment;Object"/>
+        <rdfs:range rdf:resource="&apartment;Location"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#nextTo -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#nextTo">
+    <!-- http://apartment.owl#nextTo -->
+
+    <owl:ObjectProperty rdf:about="&apartment;nextTo">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Object"/>
+        <rdfs:domain rdf:resource="&apartment;Object"/>
+        <rdfs:range rdf:resource="&apartment;Object"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#objectHasObject -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#objectHasObject">
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Object"/>
+    <!-- http://apartment.owl#objectHasObject -->
+
+    <owl:ObjectProperty rdf:about="&apartment;objectHasObject">
+        <rdfs:domain rdf:resource="&apartment;Object"/>
+        <rdfs:range rdf:resource="&apartment;Object"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#onTopOf -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#onTopOf">
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Object"/>
+    <!-- http://apartment.owl#onTopOf -->
+
+    <owl:ObjectProperty rdf:about="&apartment;onTopOf">
+        <rdfs:domain rdf:resource="&apartment;Object"/>
+        <rdfs:range rdf:resource="&apartment;Object"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#oppositeTo -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#oppositeTo">
+    <!-- http://apartment.owl#oppositeTo -->
+
+    <owl:ObjectProperty rdf:about="&apartment;oppositeTo">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Object"/>
+        <rdfs:domain rdf:resource="&apartment;Object"/>
+        <rdfs:range rdf:resource="&apartment;Object"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#orientation -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#orientation">
-        <rdfs:subPropertyOf rdf:resource="http://apartment#pose"/>
+    <!-- http://apartment.owl#orientation -->
+
+    <owl:ObjectProperty rdf:about="&apartment;orientation">
+        <rdfs:subPropertyOf rdf:resource="&apartment;pose"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#orientationPitch -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#orientationPitch">
-        <rdfs:subPropertyOf rdf:resource="http://apartment#orientation"/>
+    <!-- http://apartment.owl#orientationPitch -->
+
+    <owl:ObjectProperty rdf:about="&apartment;orientationPitch">
+        <rdfs:subPropertyOf rdf:resource="&apartment;orientation"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#orientationRoll -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#orientationRoll">
-        <rdfs:subPropertyOf rdf:resource="http://apartment#orientation"/>
+    <!-- http://apartment.owl#orientationRoll -->
+
+    <owl:ObjectProperty rdf:about="&apartment;orientationRoll">
+        <rdfs:subPropertyOf rdf:resource="&apartment;orientation"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#orientationYaw -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#orientationYaw">
-        <rdfs:subPropertyOf rdf:resource="http://apartment#orientation"/>
+    <!-- http://apartment.owl#orientationYaw -->
+
+    <owl:ObjectProperty rdf:about="&apartment;orientationYaw">
+        <rdfs:subPropertyOf rdf:resource="&apartment;orientation"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#pose -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#pose"/>
-    
+    <!-- http://apartment.owl#pose -->
+
+    <owl:ObjectProperty rdf:about="&apartment;pose"/>
 
 
-    <!-- http://apartment#position -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#position">
-        <rdfs:subPropertyOf rdf:resource="http://apartment#pose"/>
+    <!-- http://apartment.owl#position -->
+
+    <owl:ObjectProperty rdf:about="&apartment;position">
+        <rdfs:subPropertyOf rdf:resource="&apartment;pose"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#positionX -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#positionX">
-        <rdfs:subPropertyOf rdf:resource="http://apartment#position"/>
+    <!-- http://apartment.owl#positionX -->
+
+    <owl:ObjectProperty rdf:about="&apartment;positionX">
+        <rdfs:subPropertyOf rdf:resource="&apartment;position"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#positionY -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#positionY">
-        <rdfs:subPropertyOf rdf:resource="http://apartment#position"/>
+    <!-- http://apartment.owl#positionY -->
+
+    <owl:ObjectProperty rdf:about="&apartment;positionY">
+        <rdfs:subPropertyOf rdf:resource="&apartment;position"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#positionZ -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#positionZ">
-        <rdfs:subPropertyOf rdf:resource="http://apartment#position"/>
+    <!-- http://apartment.owl#positionZ -->
+
+    <owl:ObjectProperty rdf:about="&apartment;positionZ">
+        <rdfs:subPropertyOf rdf:resource="&apartment;position"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#preferredGraspingStrategy -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#preferredGraspingStrategy">
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#GraspingStrategy"/>
+    <!-- http://apartment.owl#preferredGraspingStrategy -->
+
+    <owl:ObjectProperty rdf:about="&apartment;preferredGraspingStrategy">
+        <rdfs:domain rdf:resource="&apartment;Object"/>
+        <rdfs:range rdf:resource="&apartment;GraspingStrategy"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#toTheLeftOf -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#toTheLeftOf">
-        <owl:inverseOf rdf:resource="http://apartment#toTheRightOf"/>
+    <!-- http://apartment.owl#toTheLeftOf -->
+
+    <owl:ObjectProperty rdf:about="&apartment;toTheLeftOf">
+        <owl:inverseOf rdf:resource="&apartment;toTheRightOf"/>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Object"/>
+        <rdfs:domain rdf:resource="&apartment;Object"/>
+        <rdfs:range rdf:resource="&apartment;Object"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#toTheRightOf -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#toTheRightOf">
+    <!-- http://apartment.owl#toTheRightOf -->
+
+    <owl:ObjectProperty rdf:about="&apartment;toTheRightOf">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#usedFor -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#usedFor">
+    <!-- http://apartment.owl#usedFor -->
+
+    <owl:ObjectProperty rdf:about="&apartment;usedFor">
         <rdfs:comment>This property is used to link objects or locations to some utilities such as fridge is usedFor cooling food down.</rdfs:comment>
     </owl:ObjectProperty>
-    
 
 
-    <!-- 
+
+    <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Classes
@@ -321,1453 +331,1453 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    
 
 
-    <!-- http://apartment#Alcohol -->
 
-    <owl:Class rdf:about="http://apartment#Alcohol">
-        <rdfs:subClassOf rdf:resource="http://apartment#Drink"/>
+    <!-- http://apartment.owl#Alcohol -->
+
+    <owl:Class rdf:about="&apartment;Alcohol">
+        <rdfs:subClassOf rdf:resource="&apartment;Drink"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Apple -->
 
-    <owl:Class rdf:about="http://apartment#Apple">
-        <rdfs:subClassOf rdf:resource="http://apartment#Fruit"/>
+    <!-- http://apartment.owl#Apple -->
+
+    <owl:Class rdf:about="&apartment;Apple">
+        <rdfs:subClassOf rdf:resource="&apartment;Fruit"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Appliance -->
 
-    <owl:Class rdf:about="http://apartment#Appliance">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://apartment.owl#Appliance -->
+
+    <owl:Class rdf:about="&apartment;Appliance">
+        <rdfs:subClassOf rdf:resource="&apartment;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Baking -->
 
-    <owl:Class rdf:about="http://apartment#Baking">
-        <rdfs:subClassOf rdf:resource="http://apartment#Utility"/>
+    <!-- http://apartment.owl#Baking -->
+
+    <owl:Class rdf:about="&apartment;Baking">
+        <rdfs:subClassOf rdf:resource="&apartment;Utility"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Banana -->
 
-    <owl:Class rdf:about="http://apartment#Banana">
-        <rdfs:subClassOf rdf:resource="http://apartment#Fruit"/>
+    <!-- http://apartment.owl#Banana -->
+
+    <owl:Class rdf:about="&apartment;Banana">
+        <rdfs:subClassOf rdf:resource="&apartment;Fruit"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Bed -->
 
-    <owl:Class rdf:about="http://apartment#Bed">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
+    <!-- http://apartment.owl#Bed -->
+
+    <owl:Class rdf:about="&apartment;Bed">
+        <rdfs:subClassOf rdf:resource="&apartment;Furniture"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Beef -->
 
-    <owl:Class rdf:about="http://apartment#Beef">
-        <rdfs:subClassOf rdf:resource="http://apartment#Meat"/>
+    <!-- http://apartment.owl#Beef -->
+
+    <owl:Class rdf:about="&apartment;Beef">
+        <rdfs:subClassOf rdf:resource="&apartment;Meat"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Beer -->
 
-    <owl:Class rdf:about="http://apartment#Beer">
-        <rdfs:subClassOf rdf:resource="http://apartment#Alcohol"/>
+    <!-- http://apartment.owl#Beer -->
+
+    <owl:Class rdf:about="&apartment;Beer">
+        <rdfs:subClassOf rdf:resource="&apartment;Alcohol"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Boiling -->
 
-    <owl:Class rdf:about="http://apartment#Boiling">
-        <rdfs:subClassOf rdf:resource="http://apartment#Utility"/>
+    <!-- http://apartment.owl#Boiling -->
+
+    <owl:Class rdf:about="&apartment;Boiling">
+        <rdfs:subClassOf rdf:resource="&apartment;Utility"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Bottle -->
 
-    <owl:Class rdf:about="http://apartment#Bottle">
-        <rdfs:subClassOf rdf:resource="http://apartment#DrinkContainer"/>
+    <!-- http://apartment.owl#Bottle -->
+
+    <owl:Class rdf:about="&apartment;Bottle">
+        <rdfs:subClassOf rdf:resource="&apartment;DrinkContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Bowl -->
 
-    <owl:Class rdf:about="http://apartment#Bowl">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://apartment.owl#Bowl -->
+
+    <owl:Class rdf:about="&apartment;Bowl">
+        <rdfs:subClassOf rdf:resource="&apartment;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Bread -->
 
-    <owl:Class rdf:about="http://apartment#Bread">
-        <rdfs:subClassOf rdf:resource="http://apartment#Grain"/>
+    <!-- http://apartment.owl#Bread -->
+
+    <owl:Class rdf:about="&apartment;Bread">
+        <rdfs:subClassOf rdf:resource="&apartment;Grain"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#BreadKnife -->
 
-    <owl:Class rdf:about="http://apartment#BreadKnife">
-        <rdfs:subClassOf rdf:resource="http://apartment#KitchenUtensil"/>
+    <!-- http://apartment.owl#BreadKnife -->
+
+    <owl:Class rdf:about="&apartment;BreadKnife">
+        <rdfs:subClassOf rdf:resource="&apartment;KitchenUtensil"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Broccoli -->
 
-    <owl:Class rdf:about="http://apartment#Broccoli">
-        <rdfs:subClassOf rdf:resource="http://apartment#Vegetable"/>
+    <!-- http://apartment.owl#Broccoli -->
+
+    <owl:Class rdf:about="&apartment;Broccoli">
+        <rdfs:subClassOf rdf:resource="&apartment;Vegetable"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Butter -->
 
-    <owl:Class rdf:about="http://apartment#Butter">
-        <rdfs:subClassOf rdf:resource="http://apartment#Dairy"/>
+    <!-- http://apartment.owl#Butter -->
+
+    <owl:Class rdf:about="&apartment;Butter">
+        <rdfs:subClassOf rdf:resource="&apartment;Dairy"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Buttermilk -->
 
-    <owl:Class rdf:about="http://apartment#Buttermilk">
-        <rdfs:subClassOf rdf:resource="http://apartment#Dairy"/>
+    <!-- http://apartment.owl#Buttermilk -->
+
+    <owl:Class rdf:about="&apartment;Buttermilk">
+        <rdfs:subClassOf rdf:resource="&apartment;Dairy"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Cabinet -->
 
-    <owl:Class rdf:about="http://apartment#Cabinet">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
+    <!-- http://apartment.owl#Cabinet -->
+
+    <owl:Class rdf:about="&apartment;Cabinet">
+        <rdfs:subClassOf rdf:resource="&apartment;Furniture"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Cereal -->
 
-    <owl:Class rdf:about="http://apartment#Cereal">
-        <rdfs:subClassOf rdf:resource="http://apartment#Grain"/>
+    <!-- http://apartment.owl#Cereal -->
+
+    <owl:Class rdf:about="&apartment;Cereal">
+        <rdfs:subClassOf rdf:resource="&apartment;Grain"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Chair -->
 
-    <owl:Class rdf:about="http://apartment#Chair">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
+    <!-- http://apartment.owl#Chair -->
+
+    <owl:Class rdf:about="&apartment;Chair">
+        <rdfs:subClassOf rdf:resource="&apartment;Furniture"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Cheese -->
 
-    <owl:Class rdf:about="http://apartment#Cheese">
-        <rdfs:subClassOf rdf:resource="http://apartment#Dairy"/>
+    <!-- http://apartment.owl#Cheese -->
+
+    <owl:Class rdf:about="&apartment;Cheese">
+        <rdfs:subClassOf rdf:resource="&apartment;Dairy"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Chicken -->
 
-    <owl:Class rdf:about="http://apartment#Chicken">
-        <rdfs:subClassOf rdf:resource="http://apartment#Meat"/>
+    <!-- http://apartment.owl#Chicken -->
+
+    <owl:Class rdf:about="&apartment;Chicken">
+        <rdfs:subClassOf rdf:resource="&apartment;Meat"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#ChipsCan -->
 
-    <owl:Class rdf:about="http://apartment#ChipsCan">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://apartment.owl#ChipsCan -->
+
+    <owl:Class rdf:about="&apartment;ChipsCan">
+        <rdfs:subClassOf rdf:resource="&apartment;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Clothes -->
 
-    <owl:Class rdf:about="http://apartment#Clothes">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://apartment.owl#Clothes -->
+
+    <owl:Class rdf:about="&apartment;Clothes">
+        <rdfs:subClassOf rdf:resource="&apartment;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#CoffeeCan -->
 
-    <owl:Class rdf:about="http://apartment#CoffeeCan">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://apartment.owl#CoffeeCan -->
+
+    <owl:Class rdf:about="&apartment;CoffeeCan">
+        <rdfs:subClassOf rdf:resource="&apartment;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#CoffeeTable -->
 
-    <owl:Class rdf:about="http://apartment#CoffeeTable">
-        <rdfs:subClassOf rdf:resource="http://apartment#Table"/>
+    <!-- http://apartment.owl#CoffeeTable -->
+
+    <owl:Class rdf:about="&apartment;CoffeeTable">
+        <rdfs:subClassOf rdf:resource="&apartment;Table"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Colander -->
 
-    <owl:Class rdf:about="http://apartment#Colander">
-        <rdfs:subClassOf rdf:resource="http://apartment#KitchenUtensil"/>
+    <!-- http://apartment.owl#Colander -->
+
+    <owl:Class rdf:about="&apartment;Colander">
+        <rdfs:subClassOf rdf:resource="&apartment;KitchenUtensil"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Computer -->
 
-    <owl:Class rdf:about="http://apartment#Computer">
-        <rdfs:subClassOf rdf:resource="http://apartment#Equipment"/>
+    <!-- http://apartment.owl#Computer -->
+
+    <owl:Class rdf:about="&apartment;Computer">
+        <rdfs:subClassOf rdf:resource="&apartment;Equipment"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Cookie -->
 
-    <owl:Class rdf:about="http://apartment#Cookie">
-        <rdfs:subClassOf rdf:resource="http://apartment#Snack"/>
+    <!-- http://apartment.owl#Cookie -->
+
+    <owl:Class rdf:about="&apartment;Cookie">
+        <rdfs:subClassOf rdf:resource="&apartment;Snack"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Cooking -->
 
-    <owl:Class rdf:about="http://apartment#Cooking">
-        <rdfs:subClassOf rdf:resource="http://apartment#Utility"/>
+    <!-- http://apartment.owl#Cooking -->
+
+    <owl:Class rdf:about="&apartment;Cooking">
+        <rdfs:subClassOf rdf:resource="&apartment;Utility"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#CookingUtensil -->
 
-    <owl:Class rdf:about="http://apartment#CookingUtensil">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://apartment.owl#CookingUtensil -->
+
+    <owl:Class rdf:about="&apartment;CookingUtensil">
+        <rdfs:subClassOf rdf:resource="&apartment;Object"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#Cooking"/>
+                <owl:onProperty rdf:resource="&apartment;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&apartment;Cooking"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Cooling -->
 
-    <owl:Class rdf:about="http://apartment#Cooling">
-        <rdfs:subClassOf rdf:resource="http://apartment#Utility"/>
+    <!-- http://apartment.owl#Cooling -->
+
+    <owl:Class rdf:about="&apartment;Cooling">
+        <rdfs:subClassOf rdf:resource="&apartment;Utility"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Couch -->
 
-    <owl:Class rdf:about="http://apartment#Couch">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
+    <!-- http://apartment.owl#Couch -->
+
+    <owl:Class rdf:about="&apartment;Couch">
+        <rdfs:subClassOf rdf:resource="&apartment;Furniture"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Counter -->
 
-    <owl:Class rdf:about="http://apartment#Counter">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
+    <!-- http://apartment.owl#Counter -->
+
+    <owl:Class rdf:about="&apartment;Counter">
+        <rdfs:subClassOf rdf:resource="&apartment;Furniture"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#CrackerBox -->
 
-    <owl:Class rdf:about="http://apartment#CrackerBox">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://apartment.owl#CrackerBox -->
+
+    <owl:Class rdf:about="&apartment;CrackerBox">
+        <rdfs:subClassOf rdf:resource="&apartment;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Cream -->
 
-    <owl:Class rdf:about="http://apartment#Cream">
-        <rdfs:subClassOf rdf:resource="http://apartment#Dairy"/>
+    <!-- http://apartment.owl#Cream -->
+
+    <owl:Class rdf:about="&apartment;Cream">
+        <rdfs:subClassOf rdf:resource="&apartment;Dairy"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Cup -->
 
-    <owl:Class rdf:about="http://apartment#Cup">
-        <rdfs:subClassOf rdf:resource="http://apartment#Drinkware"/>
+    <!-- http://apartment.owl#Cup -->
+
+    <owl:Class rdf:about="&apartment;Cup">
+        <rdfs:subClassOf rdf:resource="&apartment;Drinkware"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Cupboard -->
 
-    <owl:Class rdf:about="http://apartment#Cupboard">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
-        <rdfs:subClassOf rdf:resource="http://apartment#ObjectContainer"/>
+    <!-- http://apartment.owl#Cupboard -->
+
+    <owl:Class rdf:about="&apartment;Cupboard">
+        <rdfs:subClassOf rdf:resource="&apartment;Furniture"/>
+        <rdfs:subClassOf rdf:resource="&apartment;ObjectContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Dairy -->
 
-    <owl:Class rdf:about="http://apartment#Dairy">
-        <rdfs:subClassOf rdf:resource="http://apartment#Food"/>
+    <!-- http://apartment.owl#Dairy -->
+
+    <owl:Class rdf:about="&apartment;Dairy">
+        <rdfs:subClassOf rdf:resource="&apartment;Food"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#DiningRoom -->
 
-    <owl:Class rdf:about="http://apartment#DiningRoom">
-        <rdfs:subClassOf rdf:resource="http://apartment#Room"/>
+    <!-- http://apartment.owl#DiningRoom -->
+
+    <owl:Class rdf:about="&apartment;DiningRoom">
+        <rdfs:subClassOf rdf:resource="&apartment;Room"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#DiningTable -->
 
-    <owl:Class rdf:about="http://apartment#DiningTable">
-        <rdfs:subClassOf rdf:resource="http://apartment#Table"/>
+    <!-- http://apartment.owl#DiningTable -->
+
+    <owl:Class rdf:about="&apartment;DiningTable">
+        <rdfs:subClassOf rdf:resource="&apartment;Table"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#DiningTableChair -->
 
-    <owl:Class rdf:about="http://apartment#DiningTableChair">
-        <rdfs:subClassOf rdf:resource="http://apartment#Chair"/>
+    <!-- http://apartment.owl#DiningTableChair -->
+
+    <owl:Class rdf:about="&apartment;DiningTableChair">
+        <rdfs:subClassOf rdf:resource="&apartment;Chair"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Dishwasher -->
 
-    <owl:Class rdf:about="http://apartment#Dishwasher">
-        <rdfs:subClassOf rdf:resource="http://apartment#Appliance"/>
+    <!-- http://apartment.owl#Dishwasher -->
+
+    <owl:Class rdf:about="&apartment;Dishwasher">
+        <rdfs:subClassOf rdf:resource="&apartment;Appliance"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Drawer -->
 
-    <owl:Class rdf:about="http://apartment#Drawer">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
-        <rdfs:subClassOf rdf:resource="http://apartment#ObjectContainer"/>
+    <!-- http://apartment.owl#Drawer -->
+
+    <owl:Class rdf:about="&apartment;Drawer">
+        <rdfs:subClassOf rdf:resource="&apartment;Furniture"/>
+        <rdfs:subClassOf rdf:resource="&apartment;ObjectContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Drink -->
 
-    <owl:Class rdf:about="http://apartment#Drink">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://apartment.owl#Drink -->
+
+    <owl:Class rdf:about="&apartment;Drink">
+        <rdfs:subClassOf rdf:resource="&apartment;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#DrinkContainer -->
 
-    <owl:Class rdf:about="http://apartment#DrinkContainer">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://apartment.owl#DrinkContainer -->
+
+    <owl:Class rdf:about="&apartment;DrinkContainer">
+        <rdfs:subClassOf rdf:resource="&apartment;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Drinking -->
 
-    <owl:Class rdf:about="http://apartment#Drinking">
-        <rdfs:subClassOf rdf:resource="http://apartment#Utility"/>
+    <!-- http://apartment.owl#Drinking -->
+
+    <owl:Class rdf:about="&apartment;Drinking">
+        <rdfs:subClassOf rdf:resource="&apartment;Utility"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#DrinkingGlass -->
 
-    <owl:Class rdf:about="http://apartment#DrinkingGlass">
-        <rdfs:subClassOf rdf:resource="http://apartment#Drinkware"/>
+    <!-- http://apartment.owl#DrinkingGlass -->
+
+    <owl:Class rdf:about="&apartment;DrinkingGlass">
+        <rdfs:subClassOf rdf:resource="&apartment;Drinkware"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Drinkware -->
 
-    <owl:Class rdf:about="http://apartment#Drinkware">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://apartment.owl#Drinkware -->
+
+    <owl:Class rdf:about="&apartment;Drinkware">
+        <rdfs:subClassOf rdf:resource="&apartment;Object"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#Drinking"/>
+                <owl:onProperty rdf:resource="&apartment;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&apartment;Drinking"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Equipment -->
 
-    <owl:Class rdf:about="http://apartment#Equipment">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://apartment.owl#Equipment -->
+
+    <owl:Class rdf:about="&apartment;Equipment">
+        <rdfs:subClassOf rdf:resource="&apartment;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#FishCan -->
 
-    <owl:Class rdf:about="http://apartment#FishCan">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://apartment.owl#FishCan -->
+
+    <owl:Class rdf:about="&apartment;FishCan">
+        <rdfs:subClassOf rdf:resource="&apartment;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Food -->
 
-    <owl:Class rdf:about="http://apartment#Food">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://apartment.owl#Food -->
+
+    <owl:Class rdf:about="&apartment;Food">
+        <rdfs:subClassOf rdf:resource="&apartment;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#FoodContainer -->
 
-    <owl:Class rdf:about="http://apartment#FoodContainer">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://apartment.owl#FoodContainer -->
+
+    <owl:Class rdf:about="&apartment;FoodContainer">
+        <rdfs:subClassOf rdf:resource="&apartment;Object"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#StoringFood"/>
+                <owl:onProperty rdf:resource="&apartment;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&apartment;StoringFood"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Fork -->
 
-    <owl:Class rdf:about="http://apartment#Fork">
-        <rdfs:subClassOf rdf:resource="http://apartment#KitchenUtensil"/>
+    <!-- http://apartment.owl#Fork -->
+
+    <owl:Class rdf:about="&apartment;Fork">
+        <rdfs:subClassOf rdf:resource="&apartment;KitchenUtensil"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Fridge -->
 
-    <owl:Class rdf:about="http://apartment#Fridge">
-        <rdfs:subClassOf rdf:resource="http://apartment#Appliance"/>
+    <!-- http://apartment.owl#Fridge -->
+
+    <owl:Class rdf:about="&apartment;Fridge">
+        <rdfs:subClassOf rdf:resource="&apartment;Appliance"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#Cooling"/>
+                <owl:onProperty rdf:resource="&apartment;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&apartment;Cooling"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Fruit -->
 
-    <owl:Class rdf:about="http://apartment#Fruit">
-        <rdfs:subClassOf rdf:resource="http://apartment#Food"/>
+    <!-- http://apartment.owl#Fruit -->
+
+    <owl:Class rdf:about="&apartment;Fruit">
+        <rdfs:subClassOf rdf:resource="&apartment;Food"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#FryingPan -->
 
-    <owl:Class rdf:about="http://apartment#FryingPan">
-        <rdfs:subClassOf rdf:resource="http://apartment#CookingUtensil"/>
-        <owl:disjointWith rdf:resource="http://apartment#Pot"/>
+    <!-- http://apartment.owl#FryingPan -->
+
+    <owl:Class rdf:about="&apartment;FryingPan">
+        <rdfs:subClassOf rdf:resource="&apartment;CookingUtensil"/>
+        <owl:disjointWith rdf:resource="&apartment;Pot"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Furniture -->
 
-    <owl:Class rdf:about="http://apartment#Furniture">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://apartment.owl#Furniture -->
+
+    <owl:Class rdf:about="&apartment;Furniture">
+        <rdfs:subClassOf rdf:resource="&apartment;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#GelatinBox -->
 
-    <owl:Class rdf:about="http://apartment#GelatinBox">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://apartment.owl#GelatinBox -->
+
+    <owl:Class rdf:about="&apartment;GelatinBox">
+        <rdfs:subClassOf rdf:resource="&apartment;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Glass -->
 
-    <owl:Class rdf:about="http://apartment#Glass">
-        <rdfs:subClassOf rdf:resource="http://apartment#Drinkware"/>
+    <!-- http://apartment.owl#Glass -->
+
+    <owl:Class rdf:about="&apartment;Glass">
+        <rdfs:subClassOf rdf:resource="&apartment;Drinkware"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Grain -->
 
-    <owl:Class rdf:about="http://apartment#Grain">
-        <rdfs:subClassOf rdf:resource="http://apartment#Food"/>
+    <!-- http://apartment.owl#Grain -->
+
+    <owl:Class rdf:about="&apartment;Grain">
+        <rdfs:subClassOf rdf:resource="&apartment;Food"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#GraspingStrategy -->
 
-    <owl:Class rdf:about="http://apartment#GraspingStrategy">
+    <!-- http://apartment.owl#GraspingStrategy -->
+
+    <owl:Class rdf:about="&apartment;GraspingStrategy">
         <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Grater -->
 
-    <owl:Class rdf:about="http://apartment#Grater">
-        <rdfs:subClassOf rdf:resource="http://apartment#KitchenUtensil"/>
+    <!-- http://apartment.owl#Grater -->
+
+    <owl:Class rdf:about="&apartment;Grater">
+        <rdfs:subClassOf rdf:resource="&apartment;KitchenUtensil"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Ham -->
 
-    <owl:Class rdf:about="http://apartment#Ham">
-        <rdfs:subClassOf rdf:resource="http://apartment#Meat"/>
+    <!-- http://apartment.owl#Ham -->
+
+    <owl:Class rdf:about="&apartment;Ham">
+        <rdfs:subClassOf rdf:resource="&apartment;Meat"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#HandSoap -->
 
-    <owl:Class rdf:about="http://apartment#HandSoap">
-        <rdfs:subClassOf rdf:resource="http://apartment#PersonalHygieneItem"/>
+    <!-- http://apartment.owl#HandSoap -->
+
+    <owl:Class rdf:about="&apartment;HandSoap">
+        <rdfs:subClassOf rdf:resource="&apartment;PersonalHygieneItem"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Heating -->
 
-    <owl:Class rdf:about="http://apartment#Heating">
-        <rdfs:subClassOf rdf:resource="http://apartment#Utility"/>
+    <!-- http://apartment.owl#Heating -->
+
+    <owl:Class rdf:about="&apartment;Heating">
+        <rdfs:subClassOf rdf:resource="&apartment;Utility"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#IceCream -->
 
-    <owl:Class rdf:about="http://apartment#IceCream">
-        <rdfs:subClassOf rdf:resource="http://apartment#Dairy"/>
+    <!-- http://apartment.owl#IceCream -->
+
+    <owl:Class rdf:about="&apartment;IceCream">
+        <rdfs:subClassOf rdf:resource="&apartment;Dairy"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Ketchup -->
 
-    <owl:Class rdf:about="http://apartment#Ketchup">
-        <rdfs:subClassOf rdf:resource="http://apartment#Sauce"/>
+    <!-- http://apartment.owl#Ketchup -->
+
+    <owl:Class rdf:about="&apartment;Ketchup">
+        <rdfs:subClassOf rdf:resource="&apartment;Sauce"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Kitchen -->
 
-    <owl:Class rdf:about="http://apartment#Kitchen">
-        <rdfs:subClassOf rdf:resource="http://apartment#Room"/>
+    <!-- http://apartment.owl#Kitchen -->
+
+    <owl:Class rdf:about="&apartment;Kitchen">
+        <rdfs:subClassOf rdf:resource="&apartment;Room"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#KitchenUtensil -->
 
-    <owl:Class rdf:about="http://apartment#KitchenUtensil">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://apartment.owl#KitchenUtensil -->
+
+    <owl:Class rdf:about="&apartment;KitchenUtensil">
+        <rdfs:subClassOf rdf:resource="&apartment;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Knife -->
 
-    <owl:Class rdf:about="http://apartment#Knife">
-        <rdfs:subClassOf rdf:resource="http://apartment#KitchenUtensil"/>
+    <!-- http://apartment.owl#Knife -->
+
+    <owl:Class rdf:about="&apartment;Knife">
+        <rdfs:subClassOf rdf:resource="&apartment;KitchenUtensil"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Laptop -->
 
-    <owl:Class rdf:about="http://apartment#Laptop">
-        <rdfs:subClassOf rdf:resource="http://apartment#Appliance"/>
+    <!-- http://apartment.owl#Laptop -->
+
+    <owl:Class rdf:about="&apartment;Laptop">
+        <rdfs:subClassOf rdf:resource="&apartment;Appliance"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Lemon -->
 
-    <owl:Class rdf:about="http://apartment#Lemon">
-        <rdfs:subClassOf rdf:resource="http://apartment#Fruit"/>
+    <!-- http://apartment.owl#Lemon -->
+
+    <owl:Class rdf:about="&apartment;Lemon">
+        <rdfs:subClassOf rdf:resource="&apartment;Fruit"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Lettuce -->
 
-    <owl:Class rdf:about="http://apartment#Lettuce">
-        <rdfs:subClassOf rdf:resource="http://apartment#Vegetable"/>
+    <!-- http://apartment.owl#Lettuce -->
+
+    <owl:Class rdf:about="&apartment;Lettuce">
+        <rdfs:subClassOf rdf:resource="&apartment;Vegetable"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#LivingRoom -->
 
-    <owl:Class rdf:about="http://apartment#LivingRoom">
-        <rdfs:subClassOf rdf:resource="http://apartment#Room"/>
+    <!-- http://apartment.owl#LivingRoom -->
+
+    <owl:Class rdf:about="&apartment;LivingRoom">
+        <rdfs:subClassOf rdf:resource="&apartment;Room"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Location -->
 
-    <owl:Class rdf:about="http://apartment#Location">
+    <!-- http://apartment.owl#Location -->
+
+    <owl:Class rdf:about="&apartment;Location">
         <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#LunchBox -->
 
-    <owl:Class rdf:about="http://apartment#LunchBox">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://apartment.owl#LunchBox -->
+
+    <owl:Class rdf:about="&apartment;LunchBox">
+        <rdfs:subClassOf rdf:resource="&apartment;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Marker -->
 
-    <owl:Class rdf:about="http://apartment#Marker">
-        <rdfs:subClassOf rdf:resource="http://apartment#Stationery"/>
+    <!-- http://apartment.owl#Marker -->
+
+    <owl:Class rdf:about="&apartment;Marker">
+        <rdfs:subClassOf rdf:resource="&apartment;Stationery"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Mayo -->
 
-    <owl:Class rdf:about="http://apartment#Mayo">
-        <rdfs:subClassOf rdf:resource="http://apartment#Sauce"/>
+    <!-- http://apartment.owl#Mayo -->
+
+    <owl:Class rdf:about="&apartment;Mayo">
+        <rdfs:subClassOf rdf:resource="&apartment;Sauce"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Meat -->
 
-    <owl:Class rdf:about="http://apartment#Meat">
-        <rdfs:subClassOf rdf:resource="http://apartment#Food"/>
+    <!-- http://apartment.owl#Meat -->
+
+    <owl:Class rdf:about="&apartment;Meat">
+        <rdfs:subClassOf rdf:resource="&apartment;Food"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#MeatCan -->
 
-    <owl:Class rdf:about="http://apartment#MeatCan">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://apartment.owl#MeatCan -->
+
+    <owl:Class rdf:about="&apartment;MeatCan">
+        <rdfs:subClassOf rdf:resource="&apartment;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#MicrowaveOven -->
 
-    <owl:Class rdf:about="http://apartment#MicrowaveOven">
-        <rdfs:subClassOf rdf:resource="http://apartment#Appliance"/>
+    <!-- http://apartment.owl#MicrowaveOven -->
+
+    <owl:Class rdf:about="&apartment;MicrowaveOven">
+        <rdfs:subClassOf rdf:resource="&apartment;Appliance"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#Cooking"/>
+                <owl:onProperty rdf:resource="&apartment;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&apartment;Cooking"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#Heating"/>
+                <owl:onProperty rdf:resource="&apartment;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&apartment;Heating"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Milk -->
 
-    <owl:Class rdf:about="http://apartment#Milk">
-        <rdfs:subClassOf rdf:resource="http://apartment#Dairy"/>
+    <!-- http://apartment.owl#Milk -->
+
+    <owl:Class rdf:about="&apartment;Milk">
+        <rdfs:subClassOf rdf:resource="&apartment;Dairy"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Mixer -->
 
-    <owl:Class rdf:about="http://apartment#Mixer">
-        <rdfs:subClassOf rdf:resource="http://apartment#Appliance"/>
+    <!-- http://apartment.owl#Mixer -->
+
+    <owl:Class rdf:about="&apartment;Mixer">
+        <rdfs:subClassOf rdf:resource="&apartment;Appliance"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Mug -->
 
-    <owl:Class rdf:about="http://apartment#Mug">
-        <rdfs:subClassOf rdf:resource="http://apartment#Drinkware"/>
+    <!-- http://apartment.owl#Mug -->
+
+    <owl:Class rdf:about="&apartment;Mug">
+        <rdfs:subClassOf rdf:resource="&apartment;Drinkware"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Mustard -->
 
-    <owl:Class rdf:about="http://apartment#Mustard">
-        <rdfs:subClassOf rdf:resource="http://apartment#Sauce"/>
+    <!-- http://apartment.owl#Mustard -->
+
+    <owl:Class rdf:about="&apartment;Mustard">
+        <rdfs:subClassOf rdf:resource="&apartment;Sauce"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#MustardContainer -->
 
-    <owl:Class rdf:about="http://apartment#MustardContainer">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://apartment.owl#MustardContainer -->
+
+    <owl:Class rdf:about="&apartment;MustardContainer">
+        <rdfs:subClassOf rdf:resource="&apartment;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#NamedPose -->
 
-    <owl:Class rdf:about="http://apartment#NamedPose">
-        <rdfs:subClassOf rdf:resource="http://apartment#Location"/>
+    <!-- http://apartment.owl#NamedPose -->
+
+    <owl:Class rdf:about="&apartment;NamedPose">
+        <rdfs:subClassOf rdf:resource="&apartment;Location"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Object -->
 
-    <owl:Class rdf:about="http://apartment#Object">
+    <!-- http://apartment.owl#Object -->
+
+    <owl:Class rdf:about="&apartment;Object">
         <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#ObjectContainer -->
 
-    <owl:Class rdf:about="http://apartment#ObjectContainer">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://apartment.owl#ObjectContainer -->
+
+    <owl:Class rdf:about="&apartment;ObjectContainer">
+        <rdfs:subClassOf rdf:resource="&apartment;Object"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#Storing"/>
+                <owl:onProperty rdf:resource="&apartment;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&apartment;Storing"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Office -->
 
-    <owl:Class rdf:about="http://apartment#Office">
-        <rdfs:subClassOf rdf:resource="http://apartment#Room"/>
+    <!-- http://apartment.owl#Office -->
+
+    <owl:Class rdf:about="&apartment;Office">
+        <rdfs:subClassOf rdf:resource="&apartment;Room"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#OfficeChair -->
 
-    <owl:Class rdf:about="http://apartment#OfficeChair">
-        <rdfs:subClassOf rdf:resource="http://apartment#Chair"/>
+    <!-- http://apartment.owl#OfficeChair -->
+
+    <owl:Class rdf:about="&apartment;OfficeChair">
+        <rdfs:subClassOf rdf:resource="&apartment;Chair"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#OfficeTable -->
 
-    <owl:Class rdf:about="http://apartment#OfficeTable">
-        <rdfs:subClassOf rdf:resource="http://apartment#Table"/>
+    <!-- http://apartment.owl#OfficeTable -->
+
+    <owl:Class rdf:about="&apartment;OfficeTable">
+        <rdfs:subClassOf rdf:resource="&apartment;Table"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Onion -->
 
-    <owl:Class rdf:about="http://apartment#Onion">
-        <rdfs:subClassOf rdf:resource="http://apartment#Vegetable"/>
+    <!-- http://apartment.owl#Onion -->
+
+    <owl:Class rdf:about="&apartment;Onion">
+        <rdfs:subClassOf rdf:resource="&apartment;Vegetable"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Orange -->
 
-    <owl:Class rdf:about="http://apartment#Orange">
-        <rdfs:subClassOf rdf:resource="http://apartment#Fruit"/>
+    <!-- http://apartment.owl#Orange -->
+
+    <owl:Class rdf:about="&apartment;Orange">
+        <rdfs:subClassOf rdf:resource="&apartment;Fruit"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Oven -->
 
-    <owl:Class rdf:about="http://apartment#Oven">
-        <rdfs:subClassOf rdf:resource="http://apartment#Appliance"/>
+    <!-- http://apartment.owl#Oven -->
+
+    <owl:Class rdf:about="&apartment;Oven">
+        <rdfs:subClassOf rdf:resource="&apartment;Appliance"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#Baking"/>
+                <owl:onProperty rdf:resource="&apartment;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&apartment;Baking"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Paper -->
 
-    <owl:Class rdf:about="http://apartment#Paper">
-        <rdfs:subClassOf rdf:resource="http://apartment#Stationery"/>
+    <!-- http://apartment.owl#Paper -->
+
+    <owl:Class rdf:about="&apartment;Paper">
+        <rdfs:subClassOf rdf:resource="&apartment;Stationery"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#PaperClip -->
 
-    <owl:Class rdf:about="http://apartment#PaperClip">
-        <rdfs:subClassOf rdf:resource="http://apartment#Stationery"/>
+    <!-- http://apartment.owl#PaperClip -->
+
+    <owl:Class rdf:about="&apartment;PaperClip">
+        <rdfs:subClassOf rdf:resource="&apartment;Stationery"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Pasta -->
 
-    <owl:Class rdf:about="http://apartment#Pasta">
-        <rdfs:subClassOf rdf:resource="http://apartment#Grain"/>
+    <!-- http://apartment.owl#Pasta -->
+
+    <owl:Class rdf:about="&apartment;Pasta">
+        <rdfs:subClassOf rdf:resource="&apartment;Grain"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Peach -->
 
-    <owl:Class rdf:about="http://apartment#Peach">
-        <rdfs:subClassOf rdf:resource="http://apartment#Fruit"/>
+    <!-- http://apartment.owl#Peach -->
+
+    <owl:Class rdf:about="&apartment;Peach">
+        <rdfs:subClassOf rdf:resource="&apartment;Fruit"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Peanut -->
 
-    <owl:Class rdf:about="http://apartment#Peanut">
-        <rdfs:subClassOf rdf:resource="http://apartment#Snack"/>
+    <!-- http://apartment.owl#Peanut -->
+
+    <owl:Class rdf:about="&apartment;Peanut">
+        <rdfs:subClassOf rdf:resource="&apartment;Snack"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Pear -->
 
-    <owl:Class rdf:about="http://apartment#Pear">
-        <rdfs:subClassOf rdf:resource="http://apartment#Fruit"/>
+    <!-- http://apartment.owl#Pear -->
+
+    <owl:Class rdf:about="&apartment;Pear">
+        <rdfs:subClassOf rdf:resource="&apartment;Fruit"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Pen -->
 
-    <owl:Class rdf:about="http://apartment#Pen">
-        <rdfs:subClassOf rdf:resource="http://apartment#Stationery"/>
+    <!-- http://apartment.owl#Pen -->
+
+    <owl:Class rdf:about="&apartment;Pen">
+        <rdfs:subClassOf rdf:resource="&apartment;Stationery"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Pencil -->
 
-    <owl:Class rdf:about="http://apartment#Pencil">
-        <rdfs:subClassOf rdf:resource="http://apartment#Stationery"/>
+    <!-- http://apartment.owl#Pencil -->
+
+    <owl:Class rdf:about="&apartment;Pencil">
+        <rdfs:subClassOf rdf:resource="&apartment;Stationery"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#PersonalHygieneItem -->
 
-    <owl:Class rdf:about="http://apartment#PersonalHygieneItem">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://apartment.owl#PersonalHygieneItem -->
+
+    <owl:Class rdf:about="&apartment;PersonalHygieneItem">
+        <rdfs:subClassOf rdf:resource="&apartment;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Pitcher -->
 
-    <owl:Class rdf:about="http://apartment#Pitcher">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://apartment.owl#Pitcher -->
+
+    <owl:Class rdf:about="&apartment;Pitcher">
+        <rdfs:subClassOf rdf:resource="&apartment;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Plane -->
 
-    <owl:Class rdf:about="http://apartment#Plane">
+    <!-- http://apartment.owl#Plane -->
+
+    <owl:Class rdf:about="&apartment;Plane">
         <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Plate -->
 
-    <owl:Class rdf:about="http://apartment#Plate">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://apartment.owl#Plate -->
+
+    <owl:Class rdf:about="&apartment;Plate">
+        <rdfs:subClassOf rdf:resource="&apartment;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Plum -->
 
-    <owl:Class rdf:about="http://apartment#Plum">
-        <rdfs:subClassOf rdf:resource="http://apartment#Fruit"/>
+    <!-- http://apartment.owl#Plum -->
+
+    <owl:Class rdf:about="&apartment;Plum">
+        <rdfs:subClassOf rdf:resource="&apartment;Fruit"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Popcorn -->
 
-    <owl:Class rdf:about="http://apartment#Popcorn">
-        <rdfs:subClassOf rdf:resource="http://apartment#Grain"/>
+    <!-- http://apartment.owl#Popcorn -->
+
+    <owl:Class rdf:about="&apartment;Popcorn">
+        <rdfs:subClassOf rdf:resource="&apartment;Grain"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Pot -->
 
-    <owl:Class rdf:about="http://apartment#Pot">
-        <rdfs:subClassOf rdf:resource="http://apartment#CookingUtensil"/>
+    <!-- http://apartment.owl#Pot -->
+
+    <owl:Class rdf:about="&apartment;Pot">
+        <rdfs:subClassOf rdf:resource="&apartment;CookingUtensil"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#PotatoChips -->
 
-    <owl:Class rdf:about="http://apartment#PotatoChips">
-        <rdfs:subClassOf rdf:resource="http://apartment#Snack"/>
+    <!-- http://apartment.owl#PotatoChips -->
+
+    <owl:Class rdf:about="&apartment;PotatoChips">
+        <rdfs:subClassOf rdf:resource="&apartment;Snack"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#PuddingBox -->
 
-    <owl:Class rdf:about="http://apartment#PuddingBox">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://apartment.owl#PuddingBox -->
+
+    <owl:Class rdf:about="&apartment;PuddingBox">
+        <rdfs:subClassOf rdf:resource="&apartment;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Rice -->
 
-    <owl:Class rdf:about="http://apartment#Rice">
-        <rdfs:subClassOf rdf:resource="http://apartment#Grain"/>
+    <!-- http://apartment.owl#Rice -->
+
+    <owl:Class rdf:about="&apartment;Rice">
+        <rdfs:subClassOf rdf:resource="&apartment;Grain"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Robot -->
 
-    <owl:Class rdf:about="http://apartment#Robot">
-        <rdfs:subClassOf rdf:resource="http://apartment#Equipment"/>
+    <!-- http://apartment.owl#Robot -->
+
+    <owl:Class rdf:about="&apartment;Robot">
+        <rdfs:subClassOf rdf:resource="&apartment;Equipment"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Room -->
 
-    <owl:Class rdf:about="http://apartment#Room">
-        <rdfs:subClassOf rdf:resource="http://apartment#Location"/>
+    <!-- http://apartment.owl#Room -->
+
+    <owl:Class rdf:about="&apartment;Room">
+        <rdfs:subClassOf rdf:resource="&apartment;Location"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Sauce -->
 
-    <owl:Class rdf:about="http://apartment#Sauce">
-        <rdfs:subClassOf rdf:resource="http://apartment#Food"/>
+    <!-- http://apartment.owl#Sauce -->
+
+    <owl:Class rdf:about="&apartment;Sauce">
+        <rdfs:subClassOf rdf:resource="&apartment;Food"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Shampoo -->
 
-    <owl:Class rdf:about="http://apartment#Shampoo">
-        <rdfs:subClassOf rdf:resource="http://apartment#PersonalHygieneItem"/>
+    <!-- http://apartment.owl#Shampoo -->
+
+    <owl:Class rdf:about="&apartment;Shampoo">
+        <rdfs:subClassOf rdf:resource="&apartment;PersonalHygieneItem"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#ShavingCream -->
 
-    <owl:Class rdf:about="http://apartment#ShavingCream">
-        <rdfs:subClassOf rdf:resource="http://apartment#PersonalHygieneItem"/>
+    <!-- http://apartment.owl#ShavingCream -->
+
+    <owl:Class rdf:about="&apartment;ShavingCream">
+        <rdfs:subClassOf rdf:resource="&apartment;PersonalHygieneItem"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Shelf -->
 
-    <owl:Class rdf:about="http://apartment#Shelf">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
+    <!-- http://apartment.owl#Shelf -->
+
+    <owl:Class rdf:about="&apartment;Shelf">
+        <rdfs:subClassOf rdf:resource="&apartment;Furniture"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Shoes -->
 
-    <owl:Class rdf:about="http://apartment#Shoes">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://apartment.owl#Shoes -->
+
+    <owl:Class rdf:about="&apartment;Shoes">
+        <rdfs:subClassOf rdf:resource="&apartment;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#ShotGlass -->
 
-    <owl:Class rdf:about="http://apartment#ShotGlass">
-        <rdfs:subClassOf rdf:resource="http://apartment#DrinkingGlass"/>
+    <!-- http://apartment.owl#ShotGlass -->
+
+    <owl:Class rdf:about="&apartment;ShotGlass">
+        <rdfs:subClassOf rdf:resource="&apartment;DrinkingGlass"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#ShowerGel -->
 
-    <owl:Class rdf:about="http://apartment#ShowerGel">
-        <rdfs:subClassOf rdf:resource="http://apartment#PersonalHygieneItem"/>
+    <!-- http://apartment.owl#ShowerGel -->
+
+    <owl:Class rdf:about="&apartment;ShowerGel">
+        <rdfs:subClassOf rdf:resource="&apartment;PersonalHygieneItem"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Sideboard -->
 
-    <owl:Class rdf:about="http://apartment#Sideboard">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
+    <!-- http://apartment.owl#Sideboard -->
+
+    <owl:Class rdf:about="&apartment;Sideboard">
+        <rdfs:subClassOf rdf:resource="&apartment;Furniture"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Sink -->
 
-    <owl:Class rdf:about="http://apartment#Sink">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
+    <!-- http://apartment.owl#Sink -->
+
+    <owl:Class rdf:about="&apartment;Sink">
+        <rdfs:subClassOf rdf:resource="&apartment;Furniture"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Slippers -->
 
-    <owl:Class rdf:about="http://apartment#Slippers">
-        <rdfs:subClassOf rdf:resource="http://apartment#Shoes"/>
+    <!-- http://apartment.owl#Slippers -->
+
+    <owl:Class rdf:about="&apartment;Slippers">
+        <rdfs:subClassOf rdf:resource="&apartment;Shoes"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Snack -->
 
-    <owl:Class rdf:about="http://apartment#Snack">
-        <rdfs:subClassOf rdf:resource="http://apartment#Food"/>
+    <!-- http://apartment.owl#Snack -->
+
+    <owl:Class rdf:about="&apartment;Snack">
+        <rdfs:subClassOf rdf:resource="&apartment;Food"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Sockes -->
 
-    <owl:Class rdf:about="http://apartment#Sockes">
-        <rdfs:subClassOf rdf:resource="http://apartment#Clothes"/>
+    <!-- http://apartment.owl#Sockes -->
+
+    <owl:Class rdf:about="&apartment;Sockes">
+        <rdfs:subClassOf rdf:resource="&apartment;Clothes"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Sofa -->
 
-    <owl:Class rdf:about="http://apartment#Sofa">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
+    <!-- http://apartment.owl#Sofa -->
+
+    <owl:Class rdf:about="&apartment;Sofa">
+        <rdfs:subClassOf rdf:resource="&apartment;Furniture"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#SoupCan -->
 
-    <owl:Class rdf:about="http://apartment#SoupCan">
-        <rdfs:subClassOf rdf:resource="http://apartment#DrinkContainer"/>
+    <!-- http://apartment.owl#SoupCan -->
+
+    <owl:Class rdf:about="&apartment;SoupCan">
+        <rdfs:subClassOf rdf:resource="&apartment;DrinkContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#SoupPlate -->
 
-    <owl:Class rdf:about="http://apartment#SoupPlate">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://apartment.owl#SoupPlate -->
+
+    <owl:Class rdf:about="&apartment;SoupPlate">
+        <rdfs:subClassOf rdf:resource="&apartment;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Spinach -->
 
-    <owl:Class rdf:about="http://apartment#Spinach">
-        <rdfs:subClassOf rdf:resource="http://apartment#Vegetable"/>
+    <!-- http://apartment.owl#Spinach -->
+
+    <owl:Class rdf:about="&apartment;Spinach">
+        <rdfs:subClassOf rdf:resource="&apartment;Vegetable"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Stapler -->
 
-    <owl:Class rdf:about="http://apartment#Stapler">
-        <rdfs:subClassOf rdf:resource="http://apartment#Stationery"/>
+    <!-- http://apartment.owl#Stapler -->
+
+    <owl:Class rdf:about="&apartment;Stapler">
+        <rdfs:subClassOf rdf:resource="&apartment;Stationery"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Stationery -->
 
-    <owl:Class rdf:about="http://apartment#Stationery">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://apartment.owl#Stationery -->
+
+    <owl:Class rdf:about="&apartment;Stationery">
+        <rdfs:subClassOf rdf:resource="&apartment;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Storing -->
 
-    <owl:Class rdf:about="http://apartment#Storing">
-        <rdfs:subClassOf rdf:resource="http://apartment#Utility"/>
+    <!-- http://apartment.owl#Storing -->
+
+    <owl:Class rdf:about="&apartment;Storing">
+        <rdfs:subClassOf rdf:resource="&apartment;Utility"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringBooks -->
 
-    <owl:Class rdf:about="http://apartment#StoringBooks">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://apartment.owl#StoringBooks -->
+
+    <owl:Class rdf:about="&apartment;StoringBooks">
+        <rdfs:subClassOf rdf:resource="&apartment;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringBottles -->
 
-    <owl:Class rdf:about="http://apartment#StoringBottles">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://apartment.owl#StoringBottles -->
+
+    <owl:Class rdf:about="&apartment;StoringBottles">
+        <rdfs:subClassOf rdf:resource="&apartment;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringBowls -->
 
-    <owl:Class rdf:about="http://apartment#StoringBowls">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://apartment.owl#StoringBowls -->
+
+    <owl:Class rdf:about="&apartment;StoringBowls">
+        <rdfs:subClassOf rdf:resource="&apartment;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringCleaningProducts -->
 
-    <owl:Class rdf:about="http://apartment#StoringCleaningProducts">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://apartment.owl#StoringCleaningProducts -->
+
+    <owl:Class rdf:about="&apartment;StoringCleaningProducts">
+        <rdfs:subClassOf rdf:resource="&apartment;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringCups -->
 
-    <owl:Class rdf:about="http://apartment#StoringCups">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://apartment.owl#StoringCups -->
+
+    <owl:Class rdf:about="&apartment;StoringCups">
+        <rdfs:subClassOf rdf:resource="&apartment;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringCutlery -->
 
-    <owl:Class rdf:about="http://apartment#StoringCutlery">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://apartment.owl#StoringCutlery -->
+
+    <owl:Class rdf:about="&apartment;StoringCutlery">
+        <rdfs:subClassOf rdf:resource="&apartment;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringFood -->
 
-    <owl:Class rdf:about="http://apartment#StoringFood">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://apartment.owl#StoringFood -->
+
+    <owl:Class rdf:about="&apartment;StoringFood">
+        <rdfs:subClassOf rdf:resource="&apartment;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringKitchenUtensil -->
 
-    <owl:Class rdf:about="http://apartment#StoringKitchenUtensil">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://apartment.owl#StoringKitchenUtensil -->
+
+    <owl:Class rdf:about="&apartment;StoringKitchenUtensil">
+        <rdfs:subClassOf rdf:resource="&apartment;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringOil -->
 
-    <owl:Class rdf:about="http://apartment#StoringOil">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://apartment.owl#StoringOil -->
+
+    <owl:Class rdf:about="&apartment;StoringOil">
+        <rdfs:subClassOf rdf:resource="&apartment;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringPans -->
 
-    <owl:Class rdf:about="http://apartment#StoringPans">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://apartment.owl#StoringPans -->
+
+    <owl:Class rdf:about="&apartment;StoringPans">
+        <rdfs:subClassOf rdf:resource="&apartment;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringPaperPlates -->
 
-    <owl:Class rdf:about="http://apartment#StoringPaperPlates">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://apartment.owl#StoringPaperPlates -->
+
+    <owl:Class rdf:about="&apartment;StoringPaperPlates">
+        <rdfs:subClassOf rdf:resource="&apartment;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringPlasticBags -->
 
-    <owl:Class rdf:about="http://apartment#StoringPlasticBags">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://apartment.owl#StoringPlasticBags -->
+
+    <owl:Class rdf:about="&apartment;StoringPlasticBags">
+        <rdfs:subClassOf rdf:resource="&apartment;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringPlates -->
 
-    <owl:Class rdf:about="http://apartment#StoringPlates">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://apartment.owl#StoringPlates -->
+
+    <owl:Class rdf:about="&apartment;StoringPlates">
+        <rdfs:subClassOf rdf:resource="&apartment;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringPots -->
 
-    <owl:Class rdf:about="http://apartment#StoringPots">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://apartment.owl#StoringPots -->
+
+    <owl:Class rdf:about="&apartment;StoringPots">
+        <rdfs:subClassOf rdf:resource="&apartment;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringSnacks -->
 
-    <owl:Class rdf:about="http://apartment#StoringSnacks">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://apartment.owl#StoringSnacks -->
+
+    <owl:Class rdf:about="&apartment;StoringSnacks">
+        <rdfs:subClassOf rdf:resource="&apartment;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringTableCoaster -->
 
-    <owl:Class rdf:about="http://apartment#StoringTableCoaster">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://apartment.owl#StoringTableCoaster -->
+
+    <owl:Class rdf:about="&apartment;StoringTableCoaster">
+        <rdfs:subClassOf rdf:resource="&apartment;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringToys -->
 
-    <owl:Class rdf:about="http://apartment#StoringToys">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://apartment.owl#StoringToys -->
+
+    <owl:Class rdf:about="&apartment;StoringToys">
+        <rdfs:subClassOf rdf:resource="&apartment;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Stove -->
 
-    <owl:Class rdf:about="http://apartment#Stove">
-        <rdfs:subClassOf rdf:resource="http://apartment#Appliance"/>
+    <!-- http://apartment.owl#Stove -->
+
+    <owl:Class rdf:about="&apartment;Stove">
+        <rdfs:subClassOf rdf:resource="&apartment;Appliance"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#Cooking"/>
+                <owl:onProperty rdf:resource="&apartment;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&apartment;Cooking"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#Heating"/>
+                <owl:onProperty rdf:resource="&apartment;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&apartment;Heating"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Strawberry -->
 
-    <owl:Class rdf:about="http://apartment#Strawberry">
-        <rdfs:subClassOf rdf:resource="http://apartment#Fruit"/>
+    <!-- http://apartment.owl#Strawberry -->
+
+    <owl:Class rdf:about="&apartment;Strawberry">
+        <rdfs:subClassOf rdf:resource="&apartment;Fruit"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#SugarBox -->
 
-    <owl:Class rdf:about="http://apartment#SugarBox">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://apartment.owl#SugarBox -->
+
+    <owl:Class rdf:about="&apartment;SugarBox">
+        <rdfs:subClassOf rdf:resource="&apartment;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Table -->
 
-    <owl:Class rdf:about="http://apartment#Table">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
-        <rdfs:subClassOf rdf:resource="http://apartment#Plane"/>
+    <!-- http://apartment.owl#Table -->
+
+    <owl:Class rdf:about="&apartment;Table">
+        <rdfs:subClassOf rdf:resource="&apartment;Furniture"/>
+        <rdfs:subClassOf rdf:resource="&apartment;Plane"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#TableSpoon -->
 
-    <owl:Class rdf:about="http://apartment#TableSpoon">
-        <rdfs:subClassOf rdf:resource="http://apartment#KitchenUtensil"/>
+    <!-- http://apartment.owl#TableSpoon -->
+
+    <owl:Class rdf:about="&apartment;TableSpoon">
+        <rdfs:subClassOf rdf:resource="&apartment;KitchenUtensil"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Tape -->
 
-    <owl:Class rdf:about="http://apartment#Tape">
-        <rdfs:subClassOf rdf:resource="http://apartment#Stationery"/>
+    <!-- http://apartment.owl#Tape -->
+
+    <owl:Class rdf:about="&apartment;Tape">
+        <rdfs:subClassOf rdf:resource="&apartment;Stationery"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#TeaSpoon -->
 
-    <owl:Class rdf:about="http://apartment#TeaSpoon">
-        <rdfs:subClassOf rdf:resource="http://apartment#KitchenUtensil"/>
+    <!-- http://apartment.owl#TeaSpoon -->
+
+    <owl:Class rdf:about="&apartment;TeaSpoon">
+        <rdfs:subClassOf rdf:resource="&apartment;KitchenUtensil"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#ToiletPaper -->
 
-    <owl:Class rdf:about="http://apartment#ToiletPaper">
-        <rdfs:subClassOf rdf:resource="http://apartment#PersonalHygieneItem"/>
+    <!-- http://apartment.owl#ToiletPaper -->
+
+    <owl:Class rdf:about="&apartment;ToiletPaper">
+        <rdfs:subClassOf rdf:resource="&apartment;PersonalHygieneItem"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Toothbrush -->
 
-    <owl:Class rdf:about="http://apartment#Toothbrush">
-        <rdfs:subClassOf rdf:resource="http://apartment#PersonalHygieneItem"/>
+    <!-- http://apartment.owl#Toothbrush -->
+
+    <owl:Class rdf:about="&apartment;Toothbrush">
+        <rdfs:subClassOf rdf:resource="&apartment;PersonalHygieneItem"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Toothpaste -->
 
-    <owl:Class rdf:about="http://apartment#Toothpaste">
-        <rdfs:subClassOf rdf:resource="http://apartment#PersonalHygieneItem"/>
+    <!-- http://apartment.owl#Toothpaste -->
+
+    <owl:Class rdf:about="&apartment;Toothpaste">
+        <rdfs:subClassOf rdf:resource="&apartment;PersonalHygieneItem"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Toys -->
 
-    <owl:Class rdf:about="http://apartment#Toys">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://apartment.owl#Toys -->
+
+    <owl:Class rdf:about="&apartment;Toys">
+        <rdfs:subClassOf rdf:resource="&apartment;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Utility -->
 
-    <owl:Class rdf:about="http://apartment#Utility">
+    <!-- http://apartment.owl#Utility -->
+
+    <owl:Class rdf:about="&apartment;Utility">
         <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#VacuumCleaner -->
 
-    <owl:Class rdf:about="http://apartment#VacuumCleaner">
-        <rdfs:subClassOf rdf:resource="http://apartment#Appliance"/>
+    <!-- http://apartment.owl#VacuumCleaner -->
+
+    <owl:Class rdf:about="&apartment;VacuumCleaner">
+        <rdfs:subClassOf rdf:resource="&apartment;Appliance"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Vegetable -->
 
-    <owl:Class rdf:about="http://apartment#Vegetable">
-        <rdfs:subClassOf rdf:resource="http://apartment#Food"/>
+    <!-- http://apartment.owl#Vegetable -->
+
+    <owl:Class rdf:about="&apartment;Vegetable">
+        <rdfs:subClassOf rdf:resource="&apartment;Food"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Wall -->
 
-    <owl:Class rdf:about="http://apartment#Wall">
-        <rdfs:subClassOf rdf:resource="http://apartment#Location"/>
+    <!-- http://apartment.owl#Wall -->
+
+    <owl:Class rdf:about="&apartment;Wall">
+        <rdfs:subClassOf rdf:resource="&apartment;Location"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Wardrobe -->
 
-    <owl:Class rdf:about="http://apartment#Wardrobe">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
+    <!-- http://apartment.owl#Wardrobe -->
+
+    <owl:Class rdf:about="&apartment;Wardrobe">
+        <rdfs:subClassOf rdf:resource="&apartment;Furniture"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#WaterBoiler -->
 
-    <owl:Class rdf:about="http://apartment#WaterBoiler">
-        <rdfs:subClassOf rdf:resource="http://apartment#Appliance"/>
+    <!-- http://apartment.owl#WaterBoiler -->
+
+    <owl:Class rdf:about="&apartment;WaterBoiler">
+        <rdfs:subClassOf rdf:resource="&apartment;Appliance"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#Boiling"/>
+                <owl:onProperty rdf:resource="&apartment;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&apartment;Boiling"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Wine -->
 
-    <owl:Class rdf:about="http://apartment#Wine">
-        <rdfs:subClassOf rdf:resource="http://apartment#Alcohol"/>
+    <!-- http://apartment.owl#Wine -->
+
+    <owl:Class rdf:about="&apartment;Wine">
+        <rdfs:subClassOf rdf:resource="&apartment;Alcohol"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#WineGlass -->
 
-    <owl:Class rdf:about="http://apartment#WineGlass">
-        <rdfs:subClassOf rdf:resource="http://apartment#DrinkingGlass"/>
+    <!-- http://apartment.owl#WineGlass -->
+
+    <owl:Class rdf:about="&apartment;WineGlass">
+        <rdfs:subClassOf rdf:resource="&apartment;DrinkingGlass"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#WorkTable -->
 
-    <owl:Class rdf:about="http://apartment#WorkTable">
-        <rdfs:subClassOf rdf:resource="http://apartment#Table"/>
+    <!-- http://apartment.owl#WorkTable -->
+
+    <owl:Class rdf:about="&apartment;WorkTable">
+        <rdfs:subClassOf rdf:resource="&apartment;Table"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Yogurt -->
 
-    <owl:Class rdf:about="http://apartment#Yogurt">
-        <rdfs:subClassOf rdf:resource="http://apartment#Dairy"/>
+    <!-- http://apartment.owl#Yogurt -->
+
+    <owl:Class rdf:about="&apartment;Yogurt">
+        <rdfs:subClassOf rdf:resource="&apartment;Dairy"/>
     </owl:Class>
-    
+
 
 
     <!-- http://www.w3.org/2002/07/owl#Thing -->
@@ -1775,10 +1785,10 @@
     <rdf:Description rdf:about="http://www.w3.org/2002/07/owl#Thing">
         <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
     </rdf:Description>
-    
 
 
-    <!-- 
+
+    <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // General axioms
@@ -1789,80 +1799,80 @@
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://apartment#Appliance"/>
-            <rdf:Description rdf:about="http://apartment#CookingUtensil"/>
-            <rdf:Description rdf:about="http://apartment#Drinkware"/>
-            <rdf:Description rdf:about="http://apartment#FoodContainer"/>
-            <rdf:Description rdf:about="http://apartment#Furniture"/>
-            <rdf:Description rdf:about="http://apartment#KitchenUtensil"/>
-            <rdf:Description rdf:about="http://apartment#PersonalHygieneItem"/>
+            <rdf:Description rdf:about="&apartment;Appliance"/>
+            <rdf:Description rdf:about="&apartment;CookingUtensil"/>
+            <rdf:Description rdf:about="&apartment;Drinkware"/>
+            <rdf:Description rdf:about="&apartment;FoodContainer"/>
+            <rdf:Description rdf:about="&apartment;Furniture"/>
+            <rdf:Description rdf:about="&apartment;KitchenUtensil"/>
+            <rdf:Description rdf:about="&apartment;PersonalHygieneItem"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://apartment#Bed"/>
-            <rdf:Description rdf:about="http://apartment#Chair"/>
-            <rdf:Description rdf:about="http://apartment#Cupboard"/>
-            <rdf:Description rdf:about="http://apartment#DiningTable"/>
-            <rdf:Description rdf:about="http://apartment#Drawer"/>
-            <rdf:Description rdf:about="http://apartment#Sofa"/>
-            <rdf:Description rdf:about="http://apartment#Wardrobe"/>
-            <rdf:Description rdf:about="http://apartment#WorkTable"/>
+            <rdf:Description rdf:about="&apartment;Bed"/>
+            <rdf:Description rdf:about="&apartment;Chair"/>
+            <rdf:Description rdf:about="&apartment;Cupboard"/>
+            <rdf:Description rdf:about="&apartment;DiningTable"/>
+            <rdf:Description rdf:about="&apartment;Drawer"/>
+            <rdf:Description rdf:about="&apartment;Sofa"/>
+            <rdf:Description rdf:about="&apartment;Wardrobe"/>
+            <rdf:Description rdf:about="&apartment;WorkTable"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://apartment#Bowl"/>
-            <rdf:Description rdf:about="http://apartment#LunchBox"/>
-            <rdf:Description rdf:about="http://apartment#Plate"/>
-            <rdf:Description rdf:about="http://apartment#SoupPlate"/>
+            <rdf:Description rdf:about="&apartment;Bowl"/>
+            <rdf:Description rdf:about="&apartment;LunchBox"/>
+            <rdf:Description rdf:about="&apartment;Plate"/>
+            <rdf:Description rdf:about="&apartment;SoupPlate"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://apartment#BreadKnife"/>
-            <rdf:Description rdf:about="http://apartment#Fork"/>
-            <rdf:Description rdf:about="http://apartment#Knife"/>
-            <rdf:Description rdf:about="http://apartment#TableSpoon"/>
-            <rdf:Description rdf:about="http://apartment#TeaSpoon"/>
+            <rdf:Description rdf:about="&apartment;BreadKnife"/>
+            <rdf:Description rdf:about="&apartment;Fork"/>
+            <rdf:Description rdf:about="&apartment;Knife"/>
+            <rdf:Description rdf:about="&apartment;TableSpoon"/>
+            <rdf:Description rdf:about="&apartment;TeaSpoon"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://apartment#Cup"/>
-            <rdf:Description rdf:about="http://apartment#DrinkingGlass"/>
-            <rdf:Description rdf:about="http://apartment#Glass"/>
-            <rdf:Description rdf:about="http://apartment#Mug"/>
+            <rdf:Description rdf:about="&apartment;Cup"/>
+            <rdf:Description rdf:about="&apartment;DrinkingGlass"/>
+            <rdf:Description rdf:about="&apartment;Glass"/>
+            <rdf:Description rdf:about="&apartment;Mug"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://apartment#Dishwasher"/>
-            <rdf:Description rdf:about="http://apartment#Fridge"/>
-            <rdf:Description rdf:about="http://apartment#Laptop"/>
-            <rdf:Description rdf:about="http://apartment#MicrowaveOven"/>
-            <rdf:Description rdf:about="http://apartment#Mixer"/>
-            <rdf:Description rdf:about="http://apartment#Oven"/>
-            <rdf:Description rdf:about="http://apartment#Stove"/>
-            <rdf:Description rdf:about="http://apartment#VacuumCleaner"/>
-            <rdf:Description rdf:about="http://apartment#WaterBoiler"/>
+            <rdf:Description rdf:about="&apartment;Dishwasher"/>
+            <rdf:Description rdf:about="&apartment;Fridge"/>
+            <rdf:Description rdf:about="&apartment;Laptop"/>
+            <rdf:Description rdf:about="&apartment;MicrowaveOven"/>
+            <rdf:Description rdf:about="&apartment;Mixer"/>
+            <rdf:Description rdf:about="&apartment;Oven"/>
+            <rdf:Description rdf:about="&apartment;Stove"/>
+            <rdf:Description rdf:about="&apartment;VacuumCleaner"/>
+            <rdf:Description rdf:about="&apartment;WaterBoiler"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://apartment#HandSoap"/>
-            <rdf:Description rdf:about="http://apartment#Shampoo"/>
-            <rdf:Description rdf:about="http://apartment#ShavingCream"/>
-            <rdf:Description rdf:about="http://apartment#ShowerGel"/>
-            <rdf:Description rdf:about="http://apartment#ToiletPaper"/>
-            <rdf:Description rdf:about="http://apartment#Toothbrush"/>
-            <rdf:Description rdf:about="http://apartment#Toothpaste"/>
+            <rdf:Description rdf:about="&apartment;HandSoap"/>
+            <rdf:Description rdf:about="&apartment;Shampoo"/>
+            <rdf:Description rdf:about="&apartment;ShavingCream"/>
+            <rdf:Description rdf:about="&apartment;ShowerGel"/>
+            <rdf:Description rdf:about="&apartment;ToiletPaper"/>
+            <rdf:Description rdf:about="&apartment;Toothbrush"/>
+            <rdf:Description rdf:about="&apartment;Toothpaste"/>
         </owl:members>
     </rdf:Description>
 </rdf:RDF>
@@ -1870,4 +1880,3 @@
 
 
 <!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
-

--- a/common/ontology/homelab.owl
+++ b/common/ontology/homelab.owl
@@ -1,17 +1,26 @@
 <?xml version="1.0"?>
-<rdf:RDF xmlns="http://apartment"
-     xml:base="http://apartment"
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY owl2xml "http://www.w3.org/2006/12/owl2-xml#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+    <!ENTITY homelab "http://homelab.owl#" >
+]>
+
+<rdf:RDF xmlns="http://homelab.owl#"
+     xml:base="http://homelab.owl"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:xml="http://www.w3.org/XML/1998/namespace"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
      xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:apartment="http://apartment#">
-    <owl:Ontology rdf:about="http://apartment"/>
-    
+     xmlns:homelab="http://homelab.owl#">
+    <owl:Ontology rdf:about="http://homelab.owl"/>
 
 
-    <!-- 
+    <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Object Properties
@@ -19,301 +28,301 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    
 
 
-    <!-- http://apartment#above -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#above">
-        <owl:inverseOf rdf:resource="http://apartment#below"/>
+    <!-- http://homelab.owl#above -->
+
+    <owl:ObjectProperty rdf:about="&homelab;above">
+        <owl:inverseOf rdf:resource="&homelab;below"/>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Object"/>
+        <rdfs:domain rdf:resource="&homelab;Object"/>
+        <rdfs:range rdf:resource="&homelab;Object"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#below -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#below">
+    <!-- http://homelab.owl#below -->
+
+    <owl:ObjectProperty rdf:about="&homelab;below">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#canPlaceOn -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#canPlaceOn">
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Plane"/>
+    <!-- http://homelab.owl#canPlaceOn -->
+
+    <owl:ObjectProperty rdf:about="&homelab;canPlaceOn">
+        <rdfs:domain rdf:resource="&homelab;Object"/>
+        <rdfs:range rdf:resource="&homelab;Plane"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#closeTo -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#closeTo">
+    <!-- http://homelab.owl#closeTo -->
+
+    <owl:ObjectProperty rdf:about="&homelab;closeTo">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Object"/>
+        <rdfs:domain rdf:resource="&homelab;Object"/>
+        <rdfs:range rdf:resource="&homelab;Object"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#closeToWall -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#closeToWall">
+    <!-- http://homelab.owl#closeToWall -->
+
+    <owl:ObjectProperty rdf:about="&homelab;closeToWall">
         <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2002/07/owl#topObjectProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Wall"/>
+        <rdfs:domain rdf:resource="&homelab;Object"/>
+        <rdfs:range rdf:resource="&homelab;Wall"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#connectedTo -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#connectedTo">
+    <!-- http://homelab.owl#connectedTo -->
+
+    <owl:ObjectProperty rdf:about="&homelab;connectedTo">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Room"/>
-        <rdfs:range rdf:resource="http://apartment#Room"/>
+        <rdfs:domain rdf:resource="&homelab;Room"/>
+        <rdfs:range rdf:resource="&homelab;Room"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#defaultLocation -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#defaultLocation">
+    <!-- http://homelab.owl#defaultLocation -->
+
+    <owl:ObjectProperty rdf:about="&homelab;defaultLocation">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Furniture"/>
+        <rdfs:domain rdf:resource="&homelab;Object"/>
+        <rdfs:range rdf:resource="&homelab;Furniture"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#defaultStoringLocation -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#defaultStoringLocation">
+    <!-- http://homelab.owl#defaultStoringLocation -->
+
+    <owl:ObjectProperty rdf:about="&homelab;defaultStoringLocation">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Furniture"/>
+        <rdfs:domain rdf:resource="&homelab;Object"/>
+        <rdfs:range rdf:resource="&homelab;Furniture"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#hasDoor -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#hasDoor">
+    <!-- http://homelab.owl#hasDoor -->
+
+    <owl:ObjectProperty rdf:about="&homelab;hasDoor">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Furniture"/>
+        <rdfs:domain rdf:resource="&homelab;Furniture"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#hasPart -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#hasPart">
-        <owl:inverseOf rdf:resource="http://apartment#hasPart"/>
+    <!-- http://homelab.owl#hasPart -->
+
+    <owl:ObjectProperty rdf:about="&homelab;hasPart">
+        <owl:inverseOf rdf:resource="&homelab;hasPart"/>
         <rdfs:comment>This property is used to link objects to their sub-objects such as a cabinet has sub-object drawer.</rdfs:comment>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#inside -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#inside">
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Object"/>
+    <!-- http://homelab.owl#inside -->
+
+    <owl:ObjectProperty rdf:about="&homelab;inside">
+        <rdfs:domain rdf:resource="&homelab;Object"/>
+        <rdfs:range rdf:resource="&homelab;Object"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#isAtLocation -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#isAtLocation">
-        <rdfs:domain rdf:resource="http://apartment#NamedPose"/>
-        <rdfs:range rdf:resource="http://apartment#Location"/>
+    <!-- http://homelab.owl#isAtLocation -->
+
+    <owl:ObjectProperty rdf:about="&homelab;isAtLocation">
+        <rdfs:domain rdf:resource="&homelab;NamedPose"/>
+        <rdfs:range rdf:resource="&homelab;Location"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#isAtNamedPose -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#isAtNamedPose">
-        <rdfs:range rdf:resource="http://apartment#NamedPose"/>
+    <!-- http://homelab.owl#isAtNamedPose -->
+
+    <owl:ObjectProperty rdf:about="&homelab;isAtNamedPose">
+        <rdfs:range rdf:resource="&homelab;NamedPose"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#isPartOf -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#isPartOf"/>
-    
+    <!-- http://homelab.owl#isPartOf -->
+
+    <owl:ObjectProperty rdf:about="&homelab;isPartOf"/>
 
 
-    <!-- http://apartment#likelyLocation -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#likelyLocation">
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Furniture"/>
+    <!-- http://homelab.owl#likelyLocation -->
+
+    <owl:ObjectProperty rdf:about="&homelab;likelyLocation">
+        <rdfs:domain rdf:resource="&homelab;Object"/>
+        <rdfs:range rdf:resource="&homelab;Furniture"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#locatedAt -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#locatedAt">
+    <!-- http://homelab.owl#locatedAt -->
+
+    <owl:ObjectProperty rdf:about="&homelab;locatedAt">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#FunctionalProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Location"/>
+        <rdfs:domain rdf:resource="&homelab;Object"/>
+        <rdfs:range rdf:resource="&homelab;Location"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#nextTo -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#nextTo">
+    <!-- http://homelab.owl#nextTo -->
+
+    <owl:ObjectProperty rdf:about="&homelab;nextTo">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Object"/>
+        <rdfs:domain rdf:resource="&homelab;Object"/>
+        <rdfs:range rdf:resource="&homelab;Object"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#objectHasObject -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#objectHasObject">
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Object"/>
+    <!-- http://homelab.owl#objectHasObject -->
+
+    <owl:ObjectProperty rdf:about="&homelab;objectHasObject">
+        <rdfs:domain rdf:resource="&homelab;Object"/>
+        <rdfs:range rdf:resource="&homelab;Object"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#onTopOf -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#onTopOf">
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Object"/>
+    <!-- http://homelab.owl#onTopOf -->
+
+    <owl:ObjectProperty rdf:about="&homelab;onTopOf">
+        <rdfs:domain rdf:resource="&homelab;Object"/>
+        <rdfs:range rdf:resource="&homelab;Object"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#oppositeTo -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#oppositeTo">
+    <!-- http://homelab.owl#oppositeTo -->
+
+    <owl:ObjectProperty rdf:about="&homelab;oppositeTo">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#SymmetricProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Object"/>
+        <rdfs:domain rdf:resource="&homelab;Object"/>
+        <rdfs:range rdf:resource="&homelab;Object"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#orientation -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#orientation">
-        <rdfs:subPropertyOf rdf:resource="http://apartment#pose"/>
+    <!-- http://homelab.owl#orientation -->
+
+    <owl:ObjectProperty rdf:about="&homelab;orientation">
+        <rdfs:subPropertyOf rdf:resource="&homelab;pose"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#orientationPitch -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#orientationPitch">
-        <rdfs:subPropertyOf rdf:resource="http://apartment#orientation"/>
+    <!-- http://homelab.owl#orientationPitch -->
+
+    <owl:ObjectProperty rdf:about="&homelab;orientationPitch">
+        <rdfs:subPropertyOf rdf:resource="&homelab;orientation"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#orientationRoll -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#orientationRoll">
-        <rdfs:subPropertyOf rdf:resource="http://apartment#orientation"/>
+    <!-- http://homelab.owl#orientationRoll -->
+
+    <owl:ObjectProperty rdf:about="&homelab;orientationRoll">
+        <rdfs:subPropertyOf rdf:resource="&homelab;orientation"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#orientationYaw -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#orientationYaw">
-        <rdfs:subPropertyOf rdf:resource="http://apartment#orientation"/>
+    <!-- http://homelab.owl#orientationYaw -->
+
+    <owl:ObjectProperty rdf:about="&homelab;orientationYaw">
+        <rdfs:subPropertyOf rdf:resource="&homelab;orientation"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#pose -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#pose"/>
-    
+    <!-- http://homelab.owl#pose -->
+
+    <owl:ObjectProperty rdf:about="&homelab;pose"/>
 
 
-    <!-- http://apartment#position -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#position">
-        <rdfs:subPropertyOf rdf:resource="http://apartment#pose"/>
+    <!-- http://homelab.owl#position -->
+
+    <owl:ObjectProperty rdf:about="&homelab;position">
+        <rdfs:subPropertyOf rdf:resource="&homelab;pose"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#positionX -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#positionX">
-        <rdfs:subPropertyOf rdf:resource="http://apartment#position"/>
+    <!-- http://homelab.owl#positionX -->
+
+    <owl:ObjectProperty rdf:about="&homelab;positionX">
+        <rdfs:subPropertyOf rdf:resource="&homelab;position"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#positionY -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#positionY">
-        <rdfs:subPropertyOf rdf:resource="http://apartment#position"/>
+    <!-- http://homelab.owl#positionY -->
+
+    <owl:ObjectProperty rdf:about="&homelab;positionY">
+        <rdfs:subPropertyOf rdf:resource="&homelab;position"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#positionZ -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#positionZ">
-        <rdfs:subPropertyOf rdf:resource="http://apartment#position"/>
+    <!-- http://homelab.owl#positionZ -->
+
+    <owl:ObjectProperty rdf:about="&homelab;positionZ">
+        <rdfs:subPropertyOf rdf:resource="&homelab;position"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#preferredGraspingStrategy -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#preferredGraspingStrategy">
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#GraspingStrategy"/>
+    <!-- http://homelab.owl#preferredGraspingStrategy -->
+
+    <owl:ObjectProperty rdf:about="&homelab;preferredGraspingStrategy">
+        <rdfs:domain rdf:resource="&homelab;Object"/>
+        <rdfs:range rdf:resource="&homelab;GraspingStrategy"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#toTheLeftOf -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#toTheLeftOf">
-        <owl:inverseOf rdf:resource="http://apartment#toTheRightOf"/>
+    <!-- http://homelab.owl#toTheLeftOf -->
+
+    <owl:ObjectProperty rdf:about="&homelab;toTheLeftOf">
+        <owl:inverseOf rdf:resource="&homelab;toTheRightOf"/>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
-        <rdfs:domain rdf:resource="http://apartment#Object"/>
-        <rdfs:range rdf:resource="http://apartment#Object"/>
+        <rdfs:domain rdf:resource="&homelab;Object"/>
+        <rdfs:range rdf:resource="&homelab;Object"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#toTheRightOf -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#toTheRightOf">
+    <!-- http://homelab.owl#toTheRightOf -->
+
+    <owl:ObjectProperty rdf:about="&homelab;toTheRightOf">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
     </owl:ObjectProperty>
-    
 
 
-    <!-- http://apartment#usedFor -->
 
-    <owl:ObjectProperty rdf:about="http://apartment#usedFor">
+    <!-- http://homelab.owl#usedFor -->
+
+    <owl:ObjectProperty rdf:about="&homelab;usedFor">
         <rdfs:comment>This property is used to link objects or locations to some utilities such as fridge is usedFor cooling food down.</rdfs:comment>
     </owl:ObjectProperty>
-    
 
 
-    <!-- 
+
+    <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // Classes
@@ -321,1453 +330,1453 @@
     ///////////////////////////////////////////////////////////////////////////////////////
      -->
 
-    
 
 
-    <!-- http://apartment#Alcohol -->
 
-    <owl:Class rdf:about="http://apartment#Alcohol">
-        <rdfs:subClassOf rdf:resource="http://apartment#Drink"/>
+    <!-- http://homelab.owl#Alcohol -->
+
+    <owl:Class rdf:about="&homelab;Alcohol">
+        <rdfs:subClassOf rdf:resource="&homelab;Drink"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Apple -->
 
-    <owl:Class rdf:about="http://apartment#Apple">
-        <rdfs:subClassOf rdf:resource="http://apartment#Fruit"/>
+    <!-- http://homelab.owl#Apple -->
+
+    <owl:Class rdf:about="&homelab;Apple">
+        <rdfs:subClassOf rdf:resource="&homelab;Fruit"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Appliance -->
 
-    <owl:Class rdf:about="http://apartment#Appliance">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://homelab.owl#Appliance -->
+
+    <owl:Class rdf:about="&homelab;Appliance">
+        <rdfs:subClassOf rdf:resource="&homelab;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Baking -->
 
-    <owl:Class rdf:about="http://apartment#Baking">
-        <rdfs:subClassOf rdf:resource="http://apartment#Utility"/>
+    <!-- http://homelab.owl#Baking -->
+
+    <owl:Class rdf:about="&homelab;Baking">
+        <rdfs:subClassOf rdf:resource="&homelab;Utility"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Banana -->
 
-    <owl:Class rdf:about="http://apartment#Banana">
-        <rdfs:subClassOf rdf:resource="http://apartment#Fruit"/>
+    <!-- http://homelab.owl#Banana -->
+
+    <owl:Class rdf:about="&homelab;Banana">
+        <rdfs:subClassOf rdf:resource="&homelab;Fruit"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Bed -->
 
-    <owl:Class rdf:about="http://apartment#Bed">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
+    <!-- http://homelab.owl#Bed -->
+
+    <owl:Class rdf:about="&homelab;Bed">
+        <rdfs:subClassOf rdf:resource="&homelab;Furniture"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Beef -->
 
-    <owl:Class rdf:about="http://apartment#Beef">
-        <rdfs:subClassOf rdf:resource="http://apartment#Meat"/>
+    <!-- http://homelab.owl#Beef -->
+
+    <owl:Class rdf:about="&homelab;Beef">
+        <rdfs:subClassOf rdf:resource="&homelab;Meat"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Beer -->
 
-    <owl:Class rdf:about="http://apartment#Beer">
-        <rdfs:subClassOf rdf:resource="http://apartment#Alcohol"/>
+    <!-- http://homelab.owl#Beer -->
+
+    <owl:Class rdf:about="&homelab;Beer">
+        <rdfs:subClassOf rdf:resource="&homelab;Alcohol"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Boiling -->
 
-    <owl:Class rdf:about="http://apartment#Boiling">
-        <rdfs:subClassOf rdf:resource="http://apartment#Utility"/>
+    <!-- http://homelab.owl#Boiling -->
+
+    <owl:Class rdf:about="&homelab;Boiling">
+        <rdfs:subClassOf rdf:resource="&homelab;Utility"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Bottle -->
 
-    <owl:Class rdf:about="http://apartment#Bottle">
-        <rdfs:subClassOf rdf:resource="http://apartment#DrinkContainer"/>
+    <!-- http://homelab.owl#Bottle -->
+
+    <owl:Class rdf:about="&homelab;Bottle">
+        <rdfs:subClassOf rdf:resource="&homelab;DrinkContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Bowl -->
 
-    <owl:Class rdf:about="http://apartment#Bowl">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://homelab.owl#Bowl -->
+
+    <owl:Class rdf:about="&homelab;Bowl">
+        <rdfs:subClassOf rdf:resource="&homelab;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Bread -->
 
-    <owl:Class rdf:about="http://apartment#Bread">
-        <rdfs:subClassOf rdf:resource="http://apartment#Grain"/>
+    <!-- http://homelab.owl#Bread -->
+
+    <owl:Class rdf:about="&homelab;Bread">
+        <rdfs:subClassOf rdf:resource="&homelab;Grain"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#BreadKnife -->
 
-    <owl:Class rdf:about="http://apartment#BreadKnife">
-        <rdfs:subClassOf rdf:resource="http://apartment#KitchenUtensil"/>
+    <!-- http://homelab.owl#BreadKnife -->
+
+    <owl:Class rdf:about="&homelab;BreadKnife">
+        <rdfs:subClassOf rdf:resource="&homelab;KitchenUtensil"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Broccoli -->
 
-    <owl:Class rdf:about="http://apartment#Broccoli">
-        <rdfs:subClassOf rdf:resource="http://apartment#Vegetable"/>
+    <!-- http://homelab.owl#Broccoli -->
+
+    <owl:Class rdf:about="&homelab;Broccoli">
+        <rdfs:subClassOf rdf:resource="&homelab;Vegetable"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Butter -->
 
-    <owl:Class rdf:about="http://apartment#Butter">
-        <rdfs:subClassOf rdf:resource="http://apartment#Dairy"/>
+    <!-- http://homelab.owl#Butter -->
+
+    <owl:Class rdf:about="&homelab;Butter">
+        <rdfs:subClassOf rdf:resource="&homelab;Dairy"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Buttermilk -->
 
-    <owl:Class rdf:about="http://apartment#Buttermilk">
-        <rdfs:subClassOf rdf:resource="http://apartment#Dairy"/>
+    <!-- http://homelab.owl#Buttermilk -->
+
+    <owl:Class rdf:about="&homelab;Buttermilk">
+        <rdfs:subClassOf rdf:resource="&homelab;Dairy"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Cabinet -->
 
-    <owl:Class rdf:about="http://apartment#Cabinet">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
+    <!-- http://homelab.owl#Cabinet -->
+
+    <owl:Class rdf:about="&homelab;Cabinet">
+        <rdfs:subClassOf rdf:resource="&homelab;Furniture"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Cereal -->
 
-    <owl:Class rdf:about="http://apartment#Cereal">
-        <rdfs:subClassOf rdf:resource="http://apartment#Grain"/>
+    <!-- http://homelab.owl#Cereal -->
+
+    <owl:Class rdf:about="&homelab;Cereal">
+        <rdfs:subClassOf rdf:resource="&homelab;Grain"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Chair -->
 
-    <owl:Class rdf:about="http://apartment#Chair">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
+    <!-- http://homelab.owl#Chair -->
+
+    <owl:Class rdf:about="&homelab;Chair">
+        <rdfs:subClassOf rdf:resource="&homelab;Furniture"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Cheese -->
 
-    <owl:Class rdf:about="http://apartment#Cheese">
-        <rdfs:subClassOf rdf:resource="http://apartment#Dairy"/>
+    <!-- http://homelab.owl#Cheese -->
+
+    <owl:Class rdf:about="&homelab;Cheese">
+        <rdfs:subClassOf rdf:resource="&homelab;Dairy"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Chicken -->
 
-    <owl:Class rdf:about="http://apartment#Chicken">
-        <rdfs:subClassOf rdf:resource="http://apartment#Meat"/>
+    <!-- http://homelab.owl#Chicken -->
+
+    <owl:Class rdf:about="&homelab;Chicken">
+        <rdfs:subClassOf rdf:resource="&homelab;Meat"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#ChipsCan -->
 
-    <owl:Class rdf:about="http://apartment#ChipsCan">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://homelab.owl#ChipsCan -->
+
+    <owl:Class rdf:about="&homelab;ChipsCan">
+        <rdfs:subClassOf rdf:resource="&homelab;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Clothes -->
 
-    <owl:Class rdf:about="http://apartment#Clothes">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://homelab.owl#Clothes -->
+
+    <owl:Class rdf:about="&homelab;Clothes">
+        <rdfs:subClassOf rdf:resource="&homelab;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#CoffeeCan -->
 
-    <owl:Class rdf:about="http://apartment#CoffeeCan">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://homelab.owl#CoffeeCan -->
+
+    <owl:Class rdf:about="&homelab;CoffeeCan">
+        <rdfs:subClassOf rdf:resource="&homelab;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#CoffeeTable -->
 
-    <owl:Class rdf:about="http://apartment#CoffeeTable">
-        <rdfs:subClassOf rdf:resource="http://apartment#Table"/>
+    <!-- http://homelab.owl#CoffeeTable -->
+
+    <owl:Class rdf:about="&homelab;CoffeeTable">
+        <rdfs:subClassOf rdf:resource="&homelab;Table"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Colander -->
 
-    <owl:Class rdf:about="http://apartment#Colander">
-        <rdfs:subClassOf rdf:resource="http://apartment#KitchenUtensil"/>
+    <!-- http://homelab.owl#Colander -->
+
+    <owl:Class rdf:about="&homelab;Colander">
+        <rdfs:subClassOf rdf:resource="&homelab;KitchenUtensil"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Computer -->
 
-    <owl:Class rdf:about="http://apartment#Computer">
-        <rdfs:subClassOf rdf:resource="http://apartment#Equipment"/>
+    <!-- http://homelab.owl#Computer -->
+
+    <owl:Class rdf:about="&homelab;Computer">
+        <rdfs:subClassOf rdf:resource="&homelab;Equipment"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Cookie -->
 
-    <owl:Class rdf:about="http://apartment#Cookie">
-        <rdfs:subClassOf rdf:resource="http://apartment#Snack"/>
+    <!-- http://homelab.owl#Cookie -->
+
+    <owl:Class rdf:about="&homelab;Cookie">
+        <rdfs:subClassOf rdf:resource="&homelab;Snack"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Cooking -->
 
-    <owl:Class rdf:about="http://apartment#Cooking">
-        <rdfs:subClassOf rdf:resource="http://apartment#Utility"/>
+    <!-- http://homelab.owl#Cooking -->
+
+    <owl:Class rdf:about="&homelab;Cooking">
+        <rdfs:subClassOf rdf:resource="&homelab;Utility"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#CookingUtensil -->
 
-    <owl:Class rdf:about="http://apartment#CookingUtensil">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://homelab.owl#CookingUtensil -->
+
+    <owl:Class rdf:about="&homelab;CookingUtensil">
+        <rdfs:subClassOf rdf:resource="&homelab;Object"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#Cooking"/>
+                <owl:onProperty rdf:resource="&homelab;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&homelab;Cooking"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Cooling -->
 
-    <owl:Class rdf:about="http://apartment#Cooling">
-        <rdfs:subClassOf rdf:resource="http://apartment#Utility"/>
+    <!-- http://homelab.owl#Cooling -->
+
+    <owl:Class rdf:about="&homelab;Cooling">
+        <rdfs:subClassOf rdf:resource="&homelab;Utility"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Couch -->
 
-    <owl:Class rdf:about="http://apartment#Couch">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
+    <!-- http://homelab.owl#Couch -->
+
+    <owl:Class rdf:about="&homelab;Couch">
+        <rdfs:subClassOf rdf:resource="&homelab;Furniture"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Counter -->
 
-    <owl:Class rdf:about="http://apartment#Counter">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
+    <!-- http://homelab.owl#Counter -->
+
+    <owl:Class rdf:about="&homelab;Counter">
+        <rdfs:subClassOf rdf:resource="&homelab;Furniture"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#CrackerBox -->
 
-    <owl:Class rdf:about="http://apartment#CrackerBox">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://homelab.owl#CrackerBox -->
+
+    <owl:Class rdf:about="&homelab;CrackerBox">
+        <rdfs:subClassOf rdf:resource="&homelab;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Cream -->
 
-    <owl:Class rdf:about="http://apartment#Cream">
-        <rdfs:subClassOf rdf:resource="http://apartment#Dairy"/>
+    <!-- http://homelab.owl#Cream -->
+
+    <owl:Class rdf:about="&homelab;Cream">
+        <rdfs:subClassOf rdf:resource="&homelab;Dairy"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Cup -->
 
-    <owl:Class rdf:about="http://apartment#Cup">
-        <rdfs:subClassOf rdf:resource="http://apartment#Drinkware"/>
+    <!-- http://homelab.owl#Cup -->
+
+    <owl:Class rdf:about="&homelab;Cup">
+        <rdfs:subClassOf rdf:resource="&homelab;Drinkware"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Cupboard -->
 
-    <owl:Class rdf:about="http://apartment#Cupboard">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
-        <rdfs:subClassOf rdf:resource="http://apartment#ObjectContainer"/>
+    <!-- http://homelab.owl#Cupboard -->
+
+    <owl:Class rdf:about="&homelab;Cupboard">
+        <rdfs:subClassOf rdf:resource="&homelab;Furniture"/>
+        <rdfs:subClassOf rdf:resource="&homelab;ObjectContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Dairy -->
 
-    <owl:Class rdf:about="http://apartment#Dairy">
-        <rdfs:subClassOf rdf:resource="http://apartment#Food"/>
+    <!-- http://homelab.owl#Dairy -->
+
+    <owl:Class rdf:about="&homelab;Dairy">
+        <rdfs:subClassOf rdf:resource="&homelab;Food"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#DiningRoom -->
 
-    <owl:Class rdf:about="http://apartment#DiningRoom">
-        <rdfs:subClassOf rdf:resource="http://apartment#Room"/>
+    <!-- http://homelab.owl#DiningRoom -->
+
+    <owl:Class rdf:about="&homelab;DiningRoom">
+        <rdfs:subClassOf rdf:resource="&homelab;Room"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#DiningTable -->
 
-    <owl:Class rdf:about="http://apartment#DiningTable">
-        <rdfs:subClassOf rdf:resource="http://apartment#Table"/>
+    <!-- http://homelab.owl#DiningTable -->
+
+    <owl:Class rdf:about="&homelab;DiningTable">
+        <rdfs:subClassOf rdf:resource="&homelab;Table"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#DiningTableChair -->
 
-    <owl:Class rdf:about="http://apartment#DiningTableChair">
-        <rdfs:subClassOf rdf:resource="http://apartment#Chair"/>
+    <!-- http://homelab.owl#DiningTableChair -->
+
+    <owl:Class rdf:about="&homelab;DiningTableChair">
+        <rdfs:subClassOf rdf:resource="&homelab;Chair"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Dishwasher -->
 
-    <owl:Class rdf:about="http://apartment#Dishwasher">
-        <rdfs:subClassOf rdf:resource="http://apartment#Appliance"/>
+    <!-- http://homelab.owl#Dishwasher -->
+
+    <owl:Class rdf:about="&homelab;Dishwasher">
+        <rdfs:subClassOf rdf:resource="&homelab;Appliance"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Drawer -->
 
-    <owl:Class rdf:about="http://apartment#Drawer">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
-        <rdfs:subClassOf rdf:resource="http://apartment#ObjectContainer"/>
+    <!-- http://homelab.owl#Drawer -->
+
+    <owl:Class rdf:about="&homelab;Drawer">
+        <rdfs:subClassOf rdf:resource="&homelab;Furniture"/>
+        <rdfs:subClassOf rdf:resource="&homelab;ObjectContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Drink -->
 
-    <owl:Class rdf:about="http://apartment#Drink">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://homelab.owl#Drink -->
+
+    <owl:Class rdf:about="&homelab;Drink">
+        <rdfs:subClassOf rdf:resource="&homelab;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#DrinkContainer -->
 
-    <owl:Class rdf:about="http://apartment#DrinkContainer">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://homelab.owl#DrinkContainer -->
+
+    <owl:Class rdf:about="&homelab;DrinkContainer">
+        <rdfs:subClassOf rdf:resource="&homelab;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Drinking -->
 
-    <owl:Class rdf:about="http://apartment#Drinking">
-        <rdfs:subClassOf rdf:resource="http://apartment#Utility"/>
+    <!-- http://homelab.owl#Drinking -->
+
+    <owl:Class rdf:about="&homelab;Drinking">
+        <rdfs:subClassOf rdf:resource="&homelab;Utility"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#DrinkingGlass -->
 
-    <owl:Class rdf:about="http://apartment#DrinkingGlass">
-        <rdfs:subClassOf rdf:resource="http://apartment#Drinkware"/>
+    <!-- http://homelab.owl#DrinkingGlass -->
+
+    <owl:Class rdf:about="&homelab;DrinkingGlass">
+        <rdfs:subClassOf rdf:resource="&homelab;Drinkware"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Drinkware -->
 
-    <owl:Class rdf:about="http://apartment#Drinkware">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://homelab.owl#Drinkware -->
+
+    <owl:Class rdf:about="&homelab;Drinkware">
+        <rdfs:subClassOf rdf:resource="&homelab;Object"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#Drinking"/>
+                <owl:onProperty rdf:resource="&homelab;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&homelab;Drinking"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Equipment -->
 
-    <owl:Class rdf:about="http://apartment#Equipment">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://homelab.owl#Equipment -->
+
+    <owl:Class rdf:about="&homelab;Equipment">
+        <rdfs:subClassOf rdf:resource="&homelab;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#FishCan -->
 
-    <owl:Class rdf:about="http://apartment#FishCan">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://homelab.owl#FishCan -->
+
+    <owl:Class rdf:about="&homelab;FishCan">
+        <rdfs:subClassOf rdf:resource="&homelab;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Food -->
 
-    <owl:Class rdf:about="http://apartment#Food">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://homelab.owl#Food -->
+
+    <owl:Class rdf:about="&homelab;Food">
+        <rdfs:subClassOf rdf:resource="&homelab;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#FoodContainer -->
 
-    <owl:Class rdf:about="http://apartment#FoodContainer">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://homelab.owl#FoodContainer -->
+
+    <owl:Class rdf:about="&homelab;FoodContainer">
+        <rdfs:subClassOf rdf:resource="&homelab;Object"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#StoringFood"/>
+                <owl:onProperty rdf:resource="&homelab;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&homelab;StoringFood"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Fork -->
 
-    <owl:Class rdf:about="http://apartment#Fork">
-        <rdfs:subClassOf rdf:resource="http://apartment#KitchenUtensil"/>
+    <!-- http://homelab.owl#Fork -->
+
+    <owl:Class rdf:about="&homelab;Fork">
+        <rdfs:subClassOf rdf:resource="&homelab;KitchenUtensil"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Fridge -->
 
-    <owl:Class rdf:about="http://apartment#Fridge">
-        <rdfs:subClassOf rdf:resource="http://apartment#Appliance"/>
+    <!-- http://homelab.owl#Fridge -->
+
+    <owl:Class rdf:about="&homelab;Fridge">
+        <rdfs:subClassOf rdf:resource="&homelab;Appliance"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#Cooling"/>
+                <owl:onProperty rdf:resource="&homelab;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&homelab;Cooling"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Fruit -->
 
-    <owl:Class rdf:about="http://apartment#Fruit">
-        <rdfs:subClassOf rdf:resource="http://apartment#Food"/>
+    <!-- http://homelab.owl#Fruit -->
+
+    <owl:Class rdf:about="&homelab;Fruit">
+        <rdfs:subClassOf rdf:resource="&homelab;Food"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#FryingPan -->
 
-    <owl:Class rdf:about="http://apartment#FryingPan">
-        <rdfs:subClassOf rdf:resource="http://apartment#CookingUtensil"/>
-        <owl:disjointWith rdf:resource="http://apartment#Pot"/>
+    <!-- http://homelab.owl#FryingPan -->
+
+    <owl:Class rdf:about="&homelab;FryingPan">
+        <rdfs:subClassOf rdf:resource="&homelab;CookingUtensil"/>
+        <owl:disjointWith rdf:resource="&homelab;Pot"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Furniture -->
 
-    <owl:Class rdf:about="http://apartment#Furniture">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://homelab.owl#Furniture -->
+
+    <owl:Class rdf:about="&homelab;Furniture">
+        <rdfs:subClassOf rdf:resource="&homelab;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#GelatinBox -->
 
-    <owl:Class rdf:about="http://apartment#GelatinBox">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://homelab.owl#GelatinBox -->
+
+    <owl:Class rdf:about="&homelab;GelatinBox">
+        <rdfs:subClassOf rdf:resource="&homelab;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Glass -->
 
-    <owl:Class rdf:about="http://apartment#Glass">
-        <rdfs:subClassOf rdf:resource="http://apartment#Drinkware"/>
+    <!-- http://homelab.owl#Glass -->
+
+    <owl:Class rdf:about="&homelab;Glass">
+        <rdfs:subClassOf rdf:resource="&homelab;Drinkware"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Grain -->
 
-    <owl:Class rdf:about="http://apartment#Grain">
-        <rdfs:subClassOf rdf:resource="http://apartment#Food"/>
+    <!-- http://homelab.owl#Grain -->
+
+    <owl:Class rdf:about="&homelab;Grain">
+        <rdfs:subClassOf rdf:resource="&homelab;Food"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#GraspingStrategy -->
 
-    <owl:Class rdf:about="http://apartment#GraspingStrategy">
+    <!-- http://homelab.owl#GraspingStrategy -->
+
+    <owl:Class rdf:about="&homelab;GraspingStrategy">
         <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Grater -->
 
-    <owl:Class rdf:about="http://apartment#Grater">
-        <rdfs:subClassOf rdf:resource="http://apartment#KitchenUtensil"/>
+    <!-- http://homelab.owl#Grater -->
+
+    <owl:Class rdf:about="&homelab;Grater">
+        <rdfs:subClassOf rdf:resource="&homelab;KitchenUtensil"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Ham -->
 
-    <owl:Class rdf:about="http://apartment#Ham">
-        <rdfs:subClassOf rdf:resource="http://apartment#Meat"/>
+    <!-- http://homelab.owl#Ham -->
+
+    <owl:Class rdf:about="&homelab;Ham">
+        <rdfs:subClassOf rdf:resource="&homelab;Meat"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#HandSoap -->
 
-    <owl:Class rdf:about="http://apartment#HandSoap">
-        <rdfs:subClassOf rdf:resource="http://apartment#PersonalHygieneItem"/>
+    <!-- http://homelab.owl#HandSoap -->
+
+    <owl:Class rdf:about="&homelab;HandSoap">
+        <rdfs:subClassOf rdf:resource="&homelab;PersonalHygieneItem"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Heating -->
 
-    <owl:Class rdf:about="http://apartment#Heating">
-        <rdfs:subClassOf rdf:resource="http://apartment#Utility"/>
+    <!-- http://homelab.owl#Heating -->
+
+    <owl:Class rdf:about="&homelab;Heating">
+        <rdfs:subClassOf rdf:resource="&homelab;Utility"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#IceCream -->
 
-    <owl:Class rdf:about="http://apartment#IceCream">
-        <rdfs:subClassOf rdf:resource="http://apartment#Dairy"/>
+    <!-- http://homelab.owl#IceCream -->
+
+    <owl:Class rdf:about="&homelab;IceCream">
+        <rdfs:subClassOf rdf:resource="&homelab;Dairy"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Ketchup -->
 
-    <owl:Class rdf:about="http://apartment#Ketchup">
-        <rdfs:subClassOf rdf:resource="http://apartment#Sauce"/>
+    <!-- http://homelab.owl#Ketchup -->
+
+    <owl:Class rdf:about="&homelab;Ketchup">
+        <rdfs:subClassOf rdf:resource="&homelab;Sauce"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Kitchen -->
 
-    <owl:Class rdf:about="http://apartment#Kitchen">
-        <rdfs:subClassOf rdf:resource="http://apartment#Room"/>
+    <!-- http://homelab.owl#Kitchen -->
+
+    <owl:Class rdf:about="&homelab;Kitchen">
+        <rdfs:subClassOf rdf:resource="&homelab;Room"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#KitchenUtensil -->
 
-    <owl:Class rdf:about="http://apartment#KitchenUtensil">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://homelab.owl#KitchenUtensil -->
+
+    <owl:Class rdf:about="&homelab;KitchenUtensil">
+        <rdfs:subClassOf rdf:resource="&homelab;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Knife -->
 
-    <owl:Class rdf:about="http://apartment#Knife">
-        <rdfs:subClassOf rdf:resource="http://apartment#KitchenUtensil"/>
+    <!-- http://homelab.owl#Knife -->
+
+    <owl:Class rdf:about="&homelab;Knife">
+        <rdfs:subClassOf rdf:resource="&homelab;KitchenUtensil"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Laptop -->
 
-    <owl:Class rdf:about="http://apartment#Laptop">
-        <rdfs:subClassOf rdf:resource="http://apartment#Appliance"/>
+    <!-- http://homelab.owl#Laptop -->
+
+    <owl:Class rdf:about="&homelab;Laptop">
+        <rdfs:subClassOf rdf:resource="&homelab;Appliance"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Lemon -->
 
-    <owl:Class rdf:about="http://apartment#Lemon">
-        <rdfs:subClassOf rdf:resource="http://apartment#Fruit"/>
+    <!-- http://homelab.owl#Lemon -->
+
+    <owl:Class rdf:about="&homelab;Lemon">
+        <rdfs:subClassOf rdf:resource="&homelab;Fruit"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Lettuce -->
 
-    <owl:Class rdf:about="http://apartment#Lettuce">
-        <rdfs:subClassOf rdf:resource="http://apartment#Vegetable"/>
+    <!-- http://homelab.owl#Lettuce -->
+
+    <owl:Class rdf:about="&homelab;Lettuce">
+        <rdfs:subClassOf rdf:resource="&homelab;Vegetable"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#LivingRoom -->
 
-    <owl:Class rdf:about="http://apartment#LivingRoom">
-        <rdfs:subClassOf rdf:resource="http://apartment#Room"/>
+    <!-- http://homelab.owl#LivingRoom -->
+
+    <owl:Class rdf:about="&homelab;LivingRoom">
+        <rdfs:subClassOf rdf:resource="&homelab;Room"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Location -->
 
-    <owl:Class rdf:about="http://apartment#Location">
+    <!-- http://homelab.owl#Location -->
+
+    <owl:Class rdf:about="&homelab;Location">
         <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#LunchBox -->
 
-    <owl:Class rdf:about="http://apartment#LunchBox">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://homelab.owl#LunchBox -->
+
+    <owl:Class rdf:about="&homelab;LunchBox">
+        <rdfs:subClassOf rdf:resource="&homelab;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Marker -->
 
-    <owl:Class rdf:about="http://apartment#Marker">
-        <rdfs:subClassOf rdf:resource="http://apartment#Stationery"/>
+    <!-- http://homelab.owl#Marker -->
+
+    <owl:Class rdf:about="&homelab;Marker">
+        <rdfs:subClassOf rdf:resource="&homelab;Stationery"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Mayo -->
 
-    <owl:Class rdf:about="http://apartment#Mayo">
-        <rdfs:subClassOf rdf:resource="http://apartment#Sauce"/>
+    <!-- http://homelab.owl#Mayo -->
+
+    <owl:Class rdf:about="&homelab;Mayo">
+        <rdfs:subClassOf rdf:resource="&homelab;Sauce"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Meat -->
 
-    <owl:Class rdf:about="http://apartment#Meat">
-        <rdfs:subClassOf rdf:resource="http://apartment#Food"/>
+    <!-- http://homelab.owl#Meat -->
+
+    <owl:Class rdf:about="&homelab;Meat">
+        <rdfs:subClassOf rdf:resource="&homelab;Food"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#MeatCan -->
 
-    <owl:Class rdf:about="http://apartment#MeatCan">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://homelab.owl#MeatCan -->
+
+    <owl:Class rdf:about="&homelab;MeatCan">
+        <rdfs:subClassOf rdf:resource="&homelab;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#MicrowaveOven -->
 
-    <owl:Class rdf:about="http://apartment#MicrowaveOven">
-        <rdfs:subClassOf rdf:resource="http://apartment#Appliance"/>
+    <!-- http://homelab.owl#MicrowaveOven -->
+
+    <owl:Class rdf:about="&homelab;MicrowaveOven">
+        <rdfs:subClassOf rdf:resource="&homelab;Appliance"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#Cooking"/>
+                <owl:onProperty rdf:resource="&homelab;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&homelab;Cooking"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#Heating"/>
+                <owl:onProperty rdf:resource="&homelab;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&homelab;Heating"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Milk -->
 
-    <owl:Class rdf:about="http://apartment#Milk">
-        <rdfs:subClassOf rdf:resource="http://apartment#Dairy"/>
+    <!-- http://homelab.owl#Milk -->
+
+    <owl:Class rdf:about="&homelab;Milk">
+        <rdfs:subClassOf rdf:resource="&homelab;Dairy"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Mixer -->
 
-    <owl:Class rdf:about="http://apartment#Mixer">
-        <rdfs:subClassOf rdf:resource="http://apartment#Appliance"/>
+    <!-- http://homelab.owl#Mixer -->
+
+    <owl:Class rdf:about="&homelab;Mixer">
+        <rdfs:subClassOf rdf:resource="&homelab;Appliance"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Mug -->
 
-    <owl:Class rdf:about="http://apartment#Mug">
-        <rdfs:subClassOf rdf:resource="http://apartment#Drinkware"/>
+    <!-- http://homelab.owl#Mug -->
+
+    <owl:Class rdf:about="&homelab;Mug">
+        <rdfs:subClassOf rdf:resource="&homelab;Drinkware"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Mustard -->
 
-    <owl:Class rdf:about="http://apartment#Mustard">
-        <rdfs:subClassOf rdf:resource="http://apartment#Sauce"/>
+    <!-- http://homelab.owl#Mustard -->
+
+    <owl:Class rdf:about="&homelab;Mustard">
+        <rdfs:subClassOf rdf:resource="&homelab;Sauce"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#MustardContainer -->
 
-    <owl:Class rdf:about="http://apartment#MustardContainer">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://homelab.owl#MustardContainer -->
+
+    <owl:Class rdf:about="&homelab;MustardContainer">
+        <rdfs:subClassOf rdf:resource="&homelab;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#NamedPose -->
 
-    <owl:Class rdf:about="http://apartment#NamedPose">
-        <rdfs:subClassOf rdf:resource="http://apartment#Location"/>
+    <!-- http://homelab.owl#NamedPose -->
+
+    <owl:Class rdf:about="&homelab;NamedPose">
+        <rdfs:subClassOf rdf:resource="&homelab;Location"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Object -->
 
-    <owl:Class rdf:about="http://apartment#Object">
+    <!-- http://homelab.owl#Object -->
+
+    <owl:Class rdf:about="&homelab;Object">
         <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#ObjectContainer -->
 
-    <owl:Class rdf:about="http://apartment#ObjectContainer">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://homelab.owl#ObjectContainer -->
+
+    <owl:Class rdf:about="&homelab;ObjectContainer">
+        <rdfs:subClassOf rdf:resource="&homelab;Object"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#Storing"/>
+                <owl:onProperty rdf:resource="&homelab;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&homelab;Storing"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Office -->
 
-    <owl:Class rdf:about="http://apartment#Office">
-        <rdfs:subClassOf rdf:resource="http://apartment#Room"/>
+    <!-- http://homelab.owl#Office -->
+
+    <owl:Class rdf:about="&homelab;Office">
+        <rdfs:subClassOf rdf:resource="&homelab;Room"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#OfficeChair -->
 
-    <owl:Class rdf:about="http://apartment#OfficeChair">
-        <rdfs:subClassOf rdf:resource="http://apartment#Chair"/>
+    <!-- http://homelab.owl#OfficeChair -->
+
+    <owl:Class rdf:about="&homelab;OfficeChair">
+        <rdfs:subClassOf rdf:resource="&homelab;Chair"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#OfficeTable -->
 
-    <owl:Class rdf:about="http://apartment#OfficeTable">
-        <rdfs:subClassOf rdf:resource="http://apartment#Table"/>
+    <!-- http://homelab.owl#OfficeTable -->
+
+    <owl:Class rdf:about="&homelab;OfficeTable">
+        <rdfs:subClassOf rdf:resource="&homelab;Table"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Onion -->
 
-    <owl:Class rdf:about="http://apartment#Onion">
-        <rdfs:subClassOf rdf:resource="http://apartment#Vegetable"/>
+    <!-- http://homelab.owl#Onion -->
+
+    <owl:Class rdf:about="&homelab;Onion">
+        <rdfs:subClassOf rdf:resource="&homelab;Vegetable"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Orange -->
 
-    <owl:Class rdf:about="http://apartment#Orange">
-        <rdfs:subClassOf rdf:resource="http://apartment#Fruit"/>
+    <!-- http://homelab.owl#Orange -->
+
+    <owl:Class rdf:about="&homelab;Orange">
+        <rdfs:subClassOf rdf:resource="&homelab;Fruit"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Oven -->
 
-    <owl:Class rdf:about="http://apartment#Oven">
-        <rdfs:subClassOf rdf:resource="http://apartment#Appliance"/>
+    <!-- http://homelab.owl#Oven -->
+
+    <owl:Class rdf:about="&homelab;Oven">
+        <rdfs:subClassOf rdf:resource="&homelab;Appliance"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#Baking"/>
+                <owl:onProperty rdf:resource="&homelab;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&homelab;Baking"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Paper -->
 
-    <owl:Class rdf:about="http://apartment#Paper">
-        <rdfs:subClassOf rdf:resource="http://apartment#Stationery"/>
+    <!-- http://homelab.owl#Paper -->
+
+    <owl:Class rdf:about="&homelab;Paper">
+        <rdfs:subClassOf rdf:resource="&homelab;Stationery"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#PaperClip -->
 
-    <owl:Class rdf:about="http://apartment#PaperClip">
-        <rdfs:subClassOf rdf:resource="http://apartment#Stationery"/>
+    <!-- http://homelab.owl#PaperClip -->
+
+    <owl:Class rdf:about="&homelab;PaperClip">
+        <rdfs:subClassOf rdf:resource="&homelab;Stationery"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Pasta -->
 
-    <owl:Class rdf:about="http://apartment#Pasta">
-        <rdfs:subClassOf rdf:resource="http://apartment#Grain"/>
+    <!-- http://homelab.owl#Pasta -->
+
+    <owl:Class rdf:about="&homelab;Pasta">
+        <rdfs:subClassOf rdf:resource="&homelab;Grain"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Peach -->
 
-    <owl:Class rdf:about="http://apartment#Peach">
-        <rdfs:subClassOf rdf:resource="http://apartment#Fruit"/>
+    <!-- http://homelab.owl#Peach -->
+
+    <owl:Class rdf:about="&homelab;Peach">
+        <rdfs:subClassOf rdf:resource="&homelab;Fruit"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Peanut -->
 
-    <owl:Class rdf:about="http://apartment#Peanut">
-        <rdfs:subClassOf rdf:resource="http://apartment#Snack"/>
+    <!-- http://homelab.owl#Peanut -->
+
+    <owl:Class rdf:about="&homelab;Peanut">
+        <rdfs:subClassOf rdf:resource="&homelab;Snack"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Pear -->
 
-    <owl:Class rdf:about="http://apartment#Pear">
-        <rdfs:subClassOf rdf:resource="http://apartment#Fruit"/>
+    <!-- http://homelab.owl#Pear -->
+
+    <owl:Class rdf:about="&homelab;Pear">
+        <rdfs:subClassOf rdf:resource="&homelab;Fruit"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Pen -->
 
-    <owl:Class rdf:about="http://apartment#Pen">
-        <rdfs:subClassOf rdf:resource="http://apartment#Stationery"/>
+    <!-- http://homelab.owl#Pen -->
+
+    <owl:Class rdf:about="&homelab;Pen">
+        <rdfs:subClassOf rdf:resource="&homelab;Stationery"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Pencil -->
 
-    <owl:Class rdf:about="http://apartment#Pencil">
-        <rdfs:subClassOf rdf:resource="http://apartment#Stationery"/>
+    <!-- http://homelab.owl#Pencil -->
+
+    <owl:Class rdf:about="&homelab;Pencil">
+        <rdfs:subClassOf rdf:resource="&homelab;Stationery"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#PersonalHygieneItem -->
 
-    <owl:Class rdf:about="http://apartment#PersonalHygieneItem">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://homelab.owl#PersonalHygieneItem -->
+
+    <owl:Class rdf:about="&homelab;PersonalHygieneItem">
+        <rdfs:subClassOf rdf:resource="&homelab;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Pitcher -->
 
-    <owl:Class rdf:about="http://apartment#Pitcher">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://homelab.owl#Pitcher -->
+
+    <owl:Class rdf:about="&homelab;Pitcher">
+        <rdfs:subClassOf rdf:resource="&homelab;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Plane -->
 
-    <owl:Class rdf:about="http://apartment#Plane">
+    <!-- http://homelab.owl#Plane -->
+
+    <owl:Class rdf:about="&homelab;Plane">
         <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Plate -->
 
-    <owl:Class rdf:about="http://apartment#Plate">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://homelab.owl#Plate -->
+
+    <owl:Class rdf:about="&homelab;Plate">
+        <rdfs:subClassOf rdf:resource="&homelab;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Plum -->
 
-    <owl:Class rdf:about="http://apartment#Plum">
-        <rdfs:subClassOf rdf:resource="http://apartment#Fruit"/>
+    <!-- http://homelab.owl#Plum -->
+
+    <owl:Class rdf:about="&homelab;Plum">
+        <rdfs:subClassOf rdf:resource="&homelab;Fruit"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Popcorn -->
 
-    <owl:Class rdf:about="http://apartment#Popcorn">
-        <rdfs:subClassOf rdf:resource="http://apartment#Grain"/>
+    <!-- http://homelab.owl#Popcorn -->
+
+    <owl:Class rdf:about="&homelab;Popcorn">
+        <rdfs:subClassOf rdf:resource="&homelab;Grain"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Pot -->
 
-    <owl:Class rdf:about="http://apartment#Pot">
-        <rdfs:subClassOf rdf:resource="http://apartment#CookingUtensil"/>
+    <!-- http://homelab.owl#Pot -->
+
+    <owl:Class rdf:about="&homelab;Pot">
+        <rdfs:subClassOf rdf:resource="&homelab;CookingUtensil"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#PotatoChips -->
 
-    <owl:Class rdf:about="http://apartment#PotatoChips">
-        <rdfs:subClassOf rdf:resource="http://apartment#Snack"/>
+    <!-- http://homelab.owl#PotatoChips -->
+
+    <owl:Class rdf:about="&homelab;PotatoChips">
+        <rdfs:subClassOf rdf:resource="&homelab;Snack"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#PuddingBox -->
 
-    <owl:Class rdf:about="http://apartment#PuddingBox">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://homelab.owl#PuddingBox -->
+
+    <owl:Class rdf:about="&homelab;PuddingBox">
+        <rdfs:subClassOf rdf:resource="&homelab;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Rice -->
 
-    <owl:Class rdf:about="http://apartment#Rice">
-        <rdfs:subClassOf rdf:resource="http://apartment#Grain"/>
+    <!-- http://homelab.owl#Rice -->
+
+    <owl:Class rdf:about="&homelab;Rice">
+        <rdfs:subClassOf rdf:resource="&homelab;Grain"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Robot -->
 
-    <owl:Class rdf:about="http://apartment#Robot">
-        <rdfs:subClassOf rdf:resource="http://apartment#Equipment"/>
+    <!-- http://homelab.owl#Robot -->
+
+    <owl:Class rdf:about="&homelab;Robot">
+        <rdfs:subClassOf rdf:resource="&homelab;Equipment"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Room -->
 
-    <owl:Class rdf:about="http://apartment#Room">
-        <rdfs:subClassOf rdf:resource="http://apartment#Location"/>
+    <!-- http://homelab.owl#Room -->
+
+    <owl:Class rdf:about="&homelab;Room">
+        <rdfs:subClassOf rdf:resource="&homelab;Location"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Sauce -->
 
-    <owl:Class rdf:about="http://apartment#Sauce">
-        <rdfs:subClassOf rdf:resource="http://apartment#Food"/>
+    <!-- http://homelab.owl#Sauce -->
+
+    <owl:Class rdf:about="&homelab;Sauce">
+        <rdfs:subClassOf rdf:resource="&homelab;Food"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Shampoo -->
 
-    <owl:Class rdf:about="http://apartment#Shampoo">
-        <rdfs:subClassOf rdf:resource="http://apartment#PersonalHygieneItem"/>
+    <!-- http://homelab.owl#Shampoo -->
+
+    <owl:Class rdf:about="&homelab;Shampoo">
+        <rdfs:subClassOf rdf:resource="&homelab;PersonalHygieneItem"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#ShavingCream -->
 
-    <owl:Class rdf:about="http://apartment#ShavingCream">
-        <rdfs:subClassOf rdf:resource="http://apartment#PersonalHygieneItem"/>
+    <!-- http://homelab.owl#ShavingCream -->
+
+    <owl:Class rdf:about="&homelab;ShavingCream">
+        <rdfs:subClassOf rdf:resource="&homelab;PersonalHygieneItem"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Shelf -->
 
-    <owl:Class rdf:about="http://apartment#Shelf">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
+    <!-- http://homelab.owl#Shelf -->
+
+    <owl:Class rdf:about="&homelab;Shelf">
+        <rdfs:subClassOf rdf:resource="&homelab;Furniture"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Shoes -->
 
-    <owl:Class rdf:about="http://apartment#Shoes">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://homelab.owl#Shoes -->
+
+    <owl:Class rdf:about="&homelab;Shoes">
+        <rdfs:subClassOf rdf:resource="&homelab;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#ShotGlass -->
 
-    <owl:Class rdf:about="http://apartment#ShotGlass">
-        <rdfs:subClassOf rdf:resource="http://apartment#DrinkingGlass"/>
+    <!-- http://homelab.owl#ShotGlass -->
+
+    <owl:Class rdf:about="&homelab;ShotGlass">
+        <rdfs:subClassOf rdf:resource="&homelab;DrinkingGlass"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#ShowerGel -->
 
-    <owl:Class rdf:about="http://apartment#ShowerGel">
-        <rdfs:subClassOf rdf:resource="http://apartment#PersonalHygieneItem"/>
+    <!-- http://homelab.owl#ShowerGel -->
+
+    <owl:Class rdf:about="&homelab;ShowerGel">
+        <rdfs:subClassOf rdf:resource="&homelab;PersonalHygieneItem"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Sideboard -->
 
-    <owl:Class rdf:about="http://apartment#Sideboard">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
+    <!-- http://homelab.owl#Sideboard -->
+
+    <owl:Class rdf:about="&homelab;Sideboard">
+        <rdfs:subClassOf rdf:resource="&homelab;Furniture"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Sink -->
 
-    <owl:Class rdf:about="http://apartment#Sink">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
+    <!-- http://homelab.owl#Sink -->
+
+    <owl:Class rdf:about="&homelab;Sink">
+        <rdfs:subClassOf rdf:resource="&homelab;Furniture"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Slippers -->
 
-    <owl:Class rdf:about="http://apartment#Slippers">
-        <rdfs:subClassOf rdf:resource="http://apartment#Shoes"/>
+    <!-- http://homelab.owl#Slippers -->
+
+    <owl:Class rdf:about="&homelab;Slippers">
+        <rdfs:subClassOf rdf:resource="&homelab;Shoes"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Snack -->
 
-    <owl:Class rdf:about="http://apartment#Snack">
-        <rdfs:subClassOf rdf:resource="http://apartment#Food"/>
+    <!-- http://homelab.owl#Snack -->
+
+    <owl:Class rdf:about="&homelab;Snack">
+        <rdfs:subClassOf rdf:resource="&homelab;Food"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Sockes -->
 
-    <owl:Class rdf:about="http://apartment#Sockes">
-        <rdfs:subClassOf rdf:resource="http://apartment#Clothes"/>
+    <!-- http://homelab.owl#Sockes -->
+
+    <owl:Class rdf:about="&homelab;Sockes">
+        <rdfs:subClassOf rdf:resource="&homelab;Clothes"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Sofa -->
 
-    <owl:Class rdf:about="http://apartment#Sofa">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
+    <!-- http://homelab.owl#Sofa -->
+
+    <owl:Class rdf:about="&homelab;Sofa">
+        <rdfs:subClassOf rdf:resource="&homelab;Furniture"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#SoupCan -->
 
-    <owl:Class rdf:about="http://apartment#SoupCan">
-        <rdfs:subClassOf rdf:resource="http://apartment#DrinkContainer"/>
+    <!-- http://homelab.owl#SoupCan -->
+
+    <owl:Class rdf:about="&homelab;SoupCan">
+        <rdfs:subClassOf rdf:resource="&homelab;DrinkContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#SoupPlate -->
 
-    <owl:Class rdf:about="http://apartment#SoupPlate">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://homelab.owl#SoupPlate -->
+
+    <owl:Class rdf:about="&homelab;SoupPlate">
+        <rdfs:subClassOf rdf:resource="&homelab;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Spinach -->
 
-    <owl:Class rdf:about="http://apartment#Spinach">
-        <rdfs:subClassOf rdf:resource="http://apartment#Vegetable"/>
+    <!-- http://homelab.owl#Spinach -->
+
+    <owl:Class rdf:about="&homelab;Spinach">
+        <rdfs:subClassOf rdf:resource="&homelab;Vegetable"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Stapler -->
 
-    <owl:Class rdf:about="http://apartment#Stapler">
-        <rdfs:subClassOf rdf:resource="http://apartment#Stationery"/>
+    <!-- http://homelab.owl#Stapler -->
+
+    <owl:Class rdf:about="&homelab;Stapler">
+        <rdfs:subClassOf rdf:resource="&homelab;Stationery"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Stationery -->
 
-    <owl:Class rdf:about="http://apartment#Stationery">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://homelab.owl#Stationery -->
+
+    <owl:Class rdf:about="&homelab;Stationery">
+        <rdfs:subClassOf rdf:resource="&homelab;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Storing -->
 
-    <owl:Class rdf:about="http://apartment#Storing">
-        <rdfs:subClassOf rdf:resource="http://apartment#Utility"/>
+    <!-- http://homelab.owl#Storing -->
+
+    <owl:Class rdf:about="&homelab;Storing">
+        <rdfs:subClassOf rdf:resource="&homelab;Utility"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringBooks -->
 
-    <owl:Class rdf:about="http://apartment#StoringBooks">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://homelab.owl#StoringBooks -->
+
+    <owl:Class rdf:about="&homelab;StoringBooks">
+        <rdfs:subClassOf rdf:resource="&homelab;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringBottles -->
 
-    <owl:Class rdf:about="http://apartment#StoringBottles">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://homelab.owl#StoringBottles -->
+
+    <owl:Class rdf:about="&homelab;StoringBottles">
+        <rdfs:subClassOf rdf:resource="&homelab;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringBowls -->
 
-    <owl:Class rdf:about="http://apartment#StoringBowls">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://homelab.owl#StoringBowls -->
+
+    <owl:Class rdf:about="&homelab;StoringBowls">
+        <rdfs:subClassOf rdf:resource="&homelab;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringCleaningProducts -->
 
-    <owl:Class rdf:about="http://apartment#StoringCleaningProducts">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://homelab.owl#StoringCleaningProducts -->
+
+    <owl:Class rdf:about="&homelab;StoringCleaningProducts">
+        <rdfs:subClassOf rdf:resource="&homelab;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringCups -->
 
-    <owl:Class rdf:about="http://apartment#StoringCups">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://homelab.owl#StoringCups -->
+
+    <owl:Class rdf:about="&homelab;StoringCups">
+        <rdfs:subClassOf rdf:resource="&homelab;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringCutlery -->
 
-    <owl:Class rdf:about="http://apartment#StoringCutlery">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://homelab.owl#StoringCutlery -->
+
+    <owl:Class rdf:about="&homelab;StoringCutlery">
+        <rdfs:subClassOf rdf:resource="&homelab;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringFood -->
 
-    <owl:Class rdf:about="http://apartment#StoringFood">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://homelab.owl#StoringFood -->
+
+    <owl:Class rdf:about="&homelab;StoringFood">
+        <rdfs:subClassOf rdf:resource="&homelab;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringKitchenUtensil -->
 
-    <owl:Class rdf:about="http://apartment#StoringKitchenUtensil">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://homelab.owl#StoringKitchenUtensil -->
+
+    <owl:Class rdf:about="&homelab;StoringKitchenUtensil">
+        <rdfs:subClassOf rdf:resource="&homelab;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringOil -->
 
-    <owl:Class rdf:about="http://apartment#StoringOil">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://homelab.owl#StoringOil -->
+
+    <owl:Class rdf:about="&homelab;StoringOil">
+        <rdfs:subClassOf rdf:resource="&homelab;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringPans -->
 
-    <owl:Class rdf:about="http://apartment#StoringPans">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://homelab.owl#StoringPans -->
+
+    <owl:Class rdf:about="&homelab;StoringPans">
+        <rdfs:subClassOf rdf:resource="&homelab;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringPaperPlates -->
 
-    <owl:Class rdf:about="http://apartment#StoringPaperPlates">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://homelab.owl#StoringPaperPlates -->
+
+    <owl:Class rdf:about="&homelab;StoringPaperPlates">
+        <rdfs:subClassOf rdf:resource="&homelab;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringPlasticBags -->
 
-    <owl:Class rdf:about="http://apartment#StoringPlasticBags">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://homelab.owl#StoringPlasticBags -->
+
+    <owl:Class rdf:about="&homelab;StoringPlasticBags">
+        <rdfs:subClassOf rdf:resource="&homelab;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringPlates -->
 
-    <owl:Class rdf:about="http://apartment#StoringPlates">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://homelab.owl#StoringPlates -->
+
+    <owl:Class rdf:about="&homelab;StoringPlates">
+        <rdfs:subClassOf rdf:resource="&homelab;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringPots -->
 
-    <owl:Class rdf:about="http://apartment#StoringPots">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://homelab.owl#StoringPots -->
+
+    <owl:Class rdf:about="&homelab;StoringPots">
+        <rdfs:subClassOf rdf:resource="&homelab;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringSnacks -->
 
-    <owl:Class rdf:about="http://apartment#StoringSnacks">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://homelab.owl#StoringSnacks -->
+
+    <owl:Class rdf:about="&homelab;StoringSnacks">
+        <rdfs:subClassOf rdf:resource="&homelab;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringTableCoaster -->
 
-    <owl:Class rdf:about="http://apartment#StoringTableCoaster">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://homelab.owl#StoringTableCoaster -->
+
+    <owl:Class rdf:about="&homelab;StoringTableCoaster">
+        <rdfs:subClassOf rdf:resource="&homelab;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#StoringToys -->
 
-    <owl:Class rdf:about="http://apartment#StoringToys">
-        <rdfs:subClassOf rdf:resource="http://apartment#Storing"/>
+    <!-- http://homelab.owl#StoringToys -->
+
+    <owl:Class rdf:about="&homelab;StoringToys">
+        <rdfs:subClassOf rdf:resource="&homelab;Storing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Stove -->
 
-    <owl:Class rdf:about="http://apartment#Stove">
-        <rdfs:subClassOf rdf:resource="http://apartment#Appliance"/>
+    <!-- http://homelab.owl#Stove -->
+
+    <owl:Class rdf:about="&homelab;Stove">
+        <rdfs:subClassOf rdf:resource="&homelab;Appliance"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#Cooking"/>
+                <owl:onProperty rdf:resource="&homelab;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&homelab;Cooking"/>
             </owl:Restriction>
         </rdfs:subClassOf>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#Heating"/>
+                <owl:onProperty rdf:resource="&homelab;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&homelab;Heating"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Strawberry -->
 
-    <owl:Class rdf:about="http://apartment#Strawberry">
-        <rdfs:subClassOf rdf:resource="http://apartment#Fruit"/>
+    <!-- http://homelab.owl#Strawberry -->
+
+    <owl:Class rdf:about="&homelab;Strawberry">
+        <rdfs:subClassOf rdf:resource="&homelab;Fruit"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#SugarBox -->
 
-    <owl:Class rdf:about="http://apartment#SugarBox">
-        <rdfs:subClassOf rdf:resource="http://apartment#FoodContainer"/>
+    <!-- http://homelab.owl#SugarBox -->
+
+    <owl:Class rdf:about="&homelab;SugarBox">
+        <rdfs:subClassOf rdf:resource="&homelab;FoodContainer"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Table -->
 
-    <owl:Class rdf:about="http://apartment#Table">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
-        <rdfs:subClassOf rdf:resource="http://apartment#Plane"/>
+    <!-- http://homelab.owl#Table -->
+
+    <owl:Class rdf:about="&homelab;Table">
+        <rdfs:subClassOf rdf:resource="&homelab;Furniture"/>
+        <rdfs:subClassOf rdf:resource="&homelab;Plane"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#TableSpoon -->
 
-    <owl:Class rdf:about="http://apartment#TableSpoon">
-        <rdfs:subClassOf rdf:resource="http://apartment#KitchenUtensil"/>
+    <!-- http://homelab.owl#TableSpoon -->
+
+    <owl:Class rdf:about="&homelab;TableSpoon">
+        <rdfs:subClassOf rdf:resource="&homelab;KitchenUtensil"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Tape -->
 
-    <owl:Class rdf:about="http://apartment#Tape">
-        <rdfs:subClassOf rdf:resource="http://apartment#Stationery"/>
+    <!-- http://homelab.owl#Tape -->
+
+    <owl:Class rdf:about="&homelab;Tape">
+        <rdfs:subClassOf rdf:resource="&homelab;Stationery"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#TeaSpoon -->
 
-    <owl:Class rdf:about="http://apartment#TeaSpoon">
-        <rdfs:subClassOf rdf:resource="http://apartment#KitchenUtensil"/>
+    <!-- http://homelab.owl#TeaSpoon -->
+
+    <owl:Class rdf:about="&homelab;TeaSpoon">
+        <rdfs:subClassOf rdf:resource="&homelab;KitchenUtensil"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#ToiletPaper -->
 
-    <owl:Class rdf:about="http://apartment#ToiletPaper">
-        <rdfs:subClassOf rdf:resource="http://apartment#PersonalHygieneItem"/>
+    <!-- http://homelab.owl#ToiletPaper -->
+
+    <owl:Class rdf:about="&homelab;ToiletPaper">
+        <rdfs:subClassOf rdf:resource="&homelab;PersonalHygieneItem"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Toothbrush -->
 
-    <owl:Class rdf:about="http://apartment#Toothbrush">
-        <rdfs:subClassOf rdf:resource="http://apartment#PersonalHygieneItem"/>
+    <!-- http://homelab.owl#Toothbrush -->
+
+    <owl:Class rdf:about="&homelab;Toothbrush">
+        <rdfs:subClassOf rdf:resource="&homelab;PersonalHygieneItem"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Toothpaste -->
 
-    <owl:Class rdf:about="http://apartment#Toothpaste">
-        <rdfs:subClassOf rdf:resource="http://apartment#PersonalHygieneItem"/>
+    <!-- http://homelab.owl#Toothpaste -->
+
+    <owl:Class rdf:about="&homelab;Toothpaste">
+        <rdfs:subClassOf rdf:resource="&homelab;PersonalHygieneItem"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Toys -->
 
-    <owl:Class rdf:about="http://apartment#Toys">
-        <rdfs:subClassOf rdf:resource="http://apartment#Object"/>
+    <!-- http://homelab.owl#Toys -->
+
+    <owl:Class rdf:about="&homelab;Toys">
+        <rdfs:subClassOf rdf:resource="&homelab;Object"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Utility -->
 
-    <owl:Class rdf:about="http://apartment#Utility">
+    <!-- http://homelab.owl#Utility -->
+
+    <owl:Class rdf:about="&homelab;Utility">
         <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#VacuumCleaner -->
 
-    <owl:Class rdf:about="http://apartment#VacuumCleaner">
-        <rdfs:subClassOf rdf:resource="http://apartment#Appliance"/>
+    <!-- http://homelab.owl#VacuumCleaner -->
+
+    <owl:Class rdf:about="&homelab;VacuumCleaner">
+        <rdfs:subClassOf rdf:resource="&homelab;Appliance"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Vegetable -->
 
-    <owl:Class rdf:about="http://apartment#Vegetable">
-        <rdfs:subClassOf rdf:resource="http://apartment#Food"/>
+    <!-- http://homelab.owl#Vegetable -->
+
+    <owl:Class rdf:about="&homelab;Vegetable">
+        <rdfs:subClassOf rdf:resource="&homelab;Food"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Wall -->
 
-    <owl:Class rdf:about="http://apartment#Wall">
-        <rdfs:subClassOf rdf:resource="http://apartment#Location"/>
+    <!-- http://homelab.owl#Wall -->
+
+    <owl:Class rdf:about="&homelab;Wall">
+        <rdfs:subClassOf rdf:resource="&homelab;Location"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Wardrobe -->
 
-    <owl:Class rdf:about="http://apartment#Wardrobe">
-        <rdfs:subClassOf rdf:resource="http://apartment#Furniture"/>
+    <!-- http://homelab.owl#Wardrobe -->
+
+    <owl:Class rdf:about="&homelab;Wardrobe">
+        <rdfs:subClassOf rdf:resource="&homelab;Furniture"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#WaterBoiler -->
 
-    <owl:Class rdf:about="http://apartment#WaterBoiler">
-        <rdfs:subClassOf rdf:resource="http://apartment#Appliance"/>
+    <!-- http://homelab.owl#WaterBoiler -->
+
+    <owl:Class rdf:about="&homelab;WaterBoiler">
+        <rdfs:subClassOf rdf:resource="&homelab;Appliance"/>
         <rdfs:subClassOf>
             <owl:Restriction>
-                <owl:onProperty rdf:resource="http://apartment#usedFor"/>
-                <owl:someValuesFrom rdf:resource="http://apartment#Boiling"/>
+                <owl:onProperty rdf:resource="&homelab;usedFor"/>
+                <owl:someValuesFrom rdf:resource="&homelab;Boiling"/>
             </owl:Restriction>
         </rdfs:subClassOf>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Wine -->
 
-    <owl:Class rdf:about="http://apartment#Wine">
-        <rdfs:subClassOf rdf:resource="http://apartment#Alcohol"/>
+    <!-- http://homelab.owl#Wine -->
+
+    <owl:Class rdf:about="&homelab;Wine">
+        <rdfs:subClassOf rdf:resource="&homelab;Alcohol"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#WineGlass -->
 
-    <owl:Class rdf:about="http://apartment#WineGlass">
-        <rdfs:subClassOf rdf:resource="http://apartment#DrinkingGlass"/>
+    <!-- http://homelab.owl#WineGlass -->
+
+    <owl:Class rdf:about="&homelab;WineGlass">
+        <rdfs:subClassOf rdf:resource="&homelab;DrinkingGlass"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#WorkTable -->
 
-    <owl:Class rdf:about="http://apartment#WorkTable">
-        <rdfs:subClassOf rdf:resource="http://apartment#Table"/>
+    <!-- http://homelab.owl#WorkTable -->
+
+    <owl:Class rdf:about="&homelab;WorkTable">
+        <rdfs:subClassOf rdf:resource="&homelab;Table"/>
     </owl:Class>
-    
 
 
-    <!-- http://apartment#Yogurt -->
 
-    <owl:Class rdf:about="http://apartment#Yogurt">
-        <rdfs:subClassOf rdf:resource="http://apartment#Dairy"/>
+    <!-- http://homelab.owl#Yogurt -->
+
+    <owl:Class rdf:about="&homelab;Yogurt">
+        <rdfs:subClassOf rdf:resource="&homelab;Dairy"/>
     </owl:Class>
-    
+
 
 
     <!-- http://www.w3.org/2002/07/owl#Thing -->
@@ -1775,10 +1784,10 @@
     <rdf:Description rdf:about="http://www.w3.org/2002/07/owl#Thing">
         <rdfs:subClassOf rdf:resource="http://www.w3.org/2002/07/owl#Thing"/>
     </rdf:Description>
-    
 
 
-    <!-- 
+
+    <!--
     ///////////////////////////////////////////////////////////////////////////////////////
     //
     // General axioms
@@ -1789,80 +1798,80 @@
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://apartment#Appliance"/>
-            <rdf:Description rdf:about="http://apartment#CookingUtensil"/>
-            <rdf:Description rdf:about="http://apartment#Drinkware"/>
-            <rdf:Description rdf:about="http://apartment#FoodContainer"/>
-            <rdf:Description rdf:about="http://apartment#Furniture"/>
-            <rdf:Description rdf:about="http://apartment#KitchenUtensil"/>
-            <rdf:Description rdf:about="http://apartment#PersonalHygieneItem"/>
+            <rdf:Description rdf:about="&homelab;Appliance"/>
+            <rdf:Description rdf:about="&homelab;CookingUtensil"/>
+            <rdf:Description rdf:about="&homelab;Drinkware"/>
+            <rdf:Description rdf:about="&homelab;FoodContainer"/>
+            <rdf:Description rdf:about="&homelab;Furniture"/>
+            <rdf:Description rdf:about="&homelab;KitchenUtensil"/>
+            <rdf:Description rdf:about="&homelab;PersonalHygieneItem"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://apartment#Bed"/>
-            <rdf:Description rdf:about="http://apartment#Chair"/>
-            <rdf:Description rdf:about="http://apartment#Cupboard"/>
-            <rdf:Description rdf:about="http://apartment#DiningTable"/>
-            <rdf:Description rdf:about="http://apartment#Drawer"/>
-            <rdf:Description rdf:about="http://apartment#Sofa"/>
-            <rdf:Description rdf:about="http://apartment#Wardrobe"/>
-            <rdf:Description rdf:about="http://apartment#WorkTable"/>
+            <rdf:Description rdf:about="&homelab;Bed"/>
+            <rdf:Description rdf:about="&homelab;Chair"/>
+            <rdf:Description rdf:about="&homelab;Cupboard"/>
+            <rdf:Description rdf:about="&homelab;DiningTable"/>
+            <rdf:Description rdf:about="&homelab;Drawer"/>
+            <rdf:Description rdf:about="&homelab;Sofa"/>
+            <rdf:Description rdf:about="&homelab;Wardrobe"/>
+            <rdf:Description rdf:about="&homelab;WorkTable"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://apartment#Bowl"/>
-            <rdf:Description rdf:about="http://apartment#LunchBox"/>
-            <rdf:Description rdf:about="http://apartment#Plate"/>
-            <rdf:Description rdf:about="http://apartment#SoupPlate"/>
+            <rdf:Description rdf:about="&homelab;Bowl"/>
+            <rdf:Description rdf:about="&homelab;LunchBox"/>
+            <rdf:Description rdf:about="&homelab;Plate"/>
+            <rdf:Description rdf:about="&homelab;SoupPlate"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://apartment#BreadKnife"/>
-            <rdf:Description rdf:about="http://apartment#Fork"/>
-            <rdf:Description rdf:about="http://apartment#Knife"/>
-            <rdf:Description rdf:about="http://apartment#TableSpoon"/>
-            <rdf:Description rdf:about="http://apartment#TeaSpoon"/>
+            <rdf:Description rdf:about="&homelab;BreadKnife"/>
+            <rdf:Description rdf:about="&homelab;Fork"/>
+            <rdf:Description rdf:about="&homelab;Knife"/>
+            <rdf:Description rdf:about="&homelab;TableSpoon"/>
+            <rdf:Description rdf:about="&homelab;TeaSpoon"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://apartment#Cup"/>
-            <rdf:Description rdf:about="http://apartment#DrinkingGlass"/>
-            <rdf:Description rdf:about="http://apartment#Glass"/>
-            <rdf:Description rdf:about="http://apartment#Mug"/>
+            <rdf:Description rdf:about="&homelab;Cup"/>
+            <rdf:Description rdf:about="&homelab;DrinkingGlass"/>
+            <rdf:Description rdf:about="&homelab;Glass"/>
+            <rdf:Description rdf:about="&homelab;Mug"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://apartment#Dishwasher"/>
-            <rdf:Description rdf:about="http://apartment#Fridge"/>
-            <rdf:Description rdf:about="http://apartment#Laptop"/>
-            <rdf:Description rdf:about="http://apartment#MicrowaveOven"/>
-            <rdf:Description rdf:about="http://apartment#Mixer"/>
-            <rdf:Description rdf:about="http://apartment#Oven"/>
-            <rdf:Description rdf:about="http://apartment#Stove"/>
-            <rdf:Description rdf:about="http://apartment#VacuumCleaner"/>
-            <rdf:Description rdf:about="http://apartment#WaterBoiler"/>
+            <rdf:Description rdf:about="&homelab;Dishwasher"/>
+            <rdf:Description rdf:about="&homelab;Fridge"/>
+            <rdf:Description rdf:about="&homelab;Laptop"/>
+            <rdf:Description rdf:about="&homelab;MicrowaveOven"/>
+            <rdf:Description rdf:about="&homelab;Mixer"/>
+            <rdf:Description rdf:about="&homelab;Oven"/>
+            <rdf:Description rdf:about="&homelab;Stove"/>
+            <rdf:Description rdf:about="&homelab;VacuumCleaner"/>
+            <rdf:Description rdf:about="&homelab;WaterBoiler"/>
         </owl:members>
     </rdf:Description>
     <rdf:Description>
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#AllDisjointClasses"/>
         <owl:members rdf:parseType="Collection">
-            <rdf:Description rdf:about="http://apartment#HandSoap"/>
-            <rdf:Description rdf:about="http://apartment#Shampoo"/>
-            <rdf:Description rdf:about="http://apartment#ShavingCream"/>
-            <rdf:Description rdf:about="http://apartment#ShowerGel"/>
-            <rdf:Description rdf:about="http://apartment#ToiletPaper"/>
-            <rdf:Description rdf:about="http://apartment#Toothbrush"/>
-            <rdf:Description rdf:about="http://apartment#Toothpaste"/>
+            <rdf:Description rdf:about="&homelab;HandSoap"/>
+            <rdf:Description rdf:about="&homelab;Shampoo"/>
+            <rdf:Description rdf:about="&homelab;ShavingCream"/>
+            <rdf:Description rdf:about="&homelab;ShowerGel"/>
+            <rdf:Description rdf:about="&homelab;ToiletPaper"/>
+            <rdf:Description rdf:about="&homelab;Toothbrush"/>
+            <rdf:Description rdf:about="&homelab;Toothpaste"/>
         </owl:members>
     </rdf:Description>
 </rdf:RDF>
@@ -1870,4 +1879,3 @@
 
 
 <!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
-

--- a/common/tests/ontology_query_interface_unit_tests.py
+++ b/common/tests/ontology_query_interface_unit_tests.py
@@ -19,9 +19,13 @@ class ontology_query_interface_test(unittest.TestCase):
         # Get the filepath and namespace for the ontology
         self.ontology_file_path = "file://" + os.path.join(ontology_dir, "sample.owl")
         self.ontology_ns = "apartment"
+        self.entity_delimiter = "/"
+        self.base_url = None
 
         # Create an instance of the ontology interface
         self.ont_if = OntologyQueryInterface(ontology_file=self.ontology_file_path,
+                                             base_url=self.base_url,
+                                             entity_delimiter=self.entity_delimiter,
                                              class_prefix=self.ontology_ns)
 
     def test_get_classes(self):

--- a/examples/ontology_interface.ipynb
+++ b/examples/ontology_interface.ipynb
@@ -54,11 +54,13 @@
     }
    },
    "source": [
-    "Instances of the query interface expect two arguments to be passed:\n",
-    "* `ontology_url`: URL at which the ontology is exposed (if the ontology is read from a local file, the path should be prefixed by `file://`)\n",
-    "* `ontology_class_prefix`: we assume that classes are defined in a namespace, so the TBox will contain declarations of the type `prefix:Class` or `prefix:ObjectProperty`\n",
+    "Instances of the query interface expect one mandatory and three optional arguments can be passed:\n",
+    "* `ontology_url` (mandatory): URL of the ontology file (if the ontology is read from a local file, the path should be prefixed by `file://`)\n",
+    "* `base_url` (optional): a base URL for the ontology entities (if defined in the ontology itself, e.g. `http://my_ontology.owl`)\n",
+    "* `entity_delimiter` (optional): a delimiter for entity names in the ontology (a delimiter will be used if the base URL is defined; for example, if the URL is `http://my_ontology.owl` and the delimiter is `#`, entity URLs will be of the form `http://my_ontology.owl#Entity`)\n",
+    "* `ontology_class_prefix` (optional): if classes are defined in a namespace, the TBox will contain declarations of the type `prefix:Class` or `prefix:ObjectProperty`\n",
     "\n",
-    "For all examples here, we will use an ontology that was created during RoboCup German Open 2019. We host this ontology on GitHub, such that the `apartment` namespace is used for defining the ontology entities."
+    "For all examples here, we will use an ontology that was created during RoboCup German Open 2019. We host this ontology on GitHub, such that the `apartment` namespace is used for defining the ontology entities. No base URL is used for this ontology; in this case, `/` is a default entity delimiter."
    ]
   },
   {
@@ -72,8 +74,13 @@
    "outputs": [],
    "source": [
     "ontology_url = 'https://raw.githubusercontent.com/b-it-bots/mas_knowledge_base/master/common/ontology/apartment_go_2019.owl'\n",
+    "ontology_base_url = None\n",
+    "ontology_entity_delimiter = '/'\n",
     "ontology_class_prefix = 'apartment'\n",
-    "ontology_interface = OntologyQueryInterface(ontology_url, ontology_class_prefix)"
+    "ontology_interface = OntologyQueryInterface(ontology_file=ontology_url,\n",
+    "                                            base_url=ontology_base_url,\n",
+    "                                            entity_delimiter=ontology_entity_delimiter,\n",
+    "                                            class_prefix=ontology_class_prefix)"
    ]
   },
   {
@@ -1415,7 +1422,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR first of all modifies the ontology interface so that it can deal with the general case of ontology entities with full URLs. For example, entities in the KnowRob ontology have the format `http://ias.cs.tum.edu/kb/knowrob.owl#Entity`, which our interface wasn't able to deal with.

To make this possible, two additional (optional) arguments can now be passed to the ontology interface on creation:
* `base_url`: Defines the base URL of the ontology entities (in the case of KnowRob, this is `http://ias.cs.tum.edu/kb/knowrob.owl`
* `entity_delimiter`: Defines the delimiter between the base URL and the entity name (in the case of KnowRob, this is `#`)

The `class_prefix` argument is now optional as well.

The PR also modifies the `apartment.owl` and `homelab.owl` ontologies, which now have a common base URL. In particular:
* entities in the `apartment` ontology have the form `http://apartment.owl#Entity`
* entities in the `homelab` ontology have the form `http://homelab.owl#Entity`

The base URL is defined in the same was as in KnowRob (as an entity) so that it doesn't have to be repeated for every class and property.

The Jupyter notebook with examples of using ontology query interface and the unit tests for the interface have been updated accordingly.

cc @munaibalhelali 